### PR TITLE
feat: add TypeScript definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	},
 	"scripts": {
 		"changelog": "conventional-changelog -p @commitlint/config-conventional -s -i CHANGELOG.md && prettier CHANGELOG.md --write",
-		"doc": "jsdoc2md src/index.js > API.md && prettier API.md --write",
+		"doc": "tsc && jsdoc2md src/index.js > API.md && prettier API.md --write",
 		"dupe-check": "yarn jsinspect ./src",
 		"lint": "eslint . --cache --ext js,jsx,ts,tsx --ignore-path .gitignore",
 		"prettier": "prettier . --write --ignore-path .gitignore",
@@ -75,6 +75,7 @@
 		"jest": "^26.5.3",
 		"jsdoc-to-markdown": "^6.0.1",
 		"jsinspect": "^0.12.7",
-		"prettier": "2.1.2"
+		"prettier": "2.1.2",
+		"typescript": "^4.0.3"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ class Poppler {
 	/**
 	 * @author Frazer Smith
 	 * @description Embeds files (attachments) into a PDF file.
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {boolean=} options.printVersionInfo - Print copyright and version info.
 	 * @param {boolean=} options.replace - Replace embedded file with same name (if it exists).
 	 * @param {string} file - Filepath of the PDF file to read.
@@ -121,7 +121,7 @@ class Poppler {
 	 * @author Frazer Smith
 	 * @description Lists or extracts embedded files (attachments) from a PDF file.
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {boolean=} options.listEmbedded - List all of the embedded files in the PDF file.
 	 * File names are converted to the text encoding specified by the `outputEncoding` option.
 	 * @param {string=} options.ownerPassword - Owner password (for encrypted files).
@@ -175,7 +175,7 @@ class Poppler {
 	 * @author Frazer Smith
 	 * @description Lists the fonts used in a PDF file along with various information for each font.
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {number=} options.firstPageToExamine - Specifies the first page to examine.
 	 * @param {number=} options.lastPageToExamine - Specifies the last page to examine.
 	 * @param {boolean=} options.listSubstitutes - List the substitute fonts that poppler
@@ -214,7 +214,7 @@ class Poppler {
 	 * @author Frazer Smith
 	 * @description Saves images from a PDF file as PPM, PBM, PNG, TIFF, JPEG, JPEG2000, or JBIG2 files.
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {boolean=} options.allFiles - Write JPEG, JPEG2000, JBIG2, and CCITT images in their native format.
 	 * CMYK files are written as TIFF files. All other images are written as PNG files.
 	 * @param {boolean=} options.ccittFile - Generate CCITT images as CCITT files.
@@ -273,7 +273,7 @@ class Poppler {
 	 * @author Frazer Smith
 	 * @description Prints the contents of the `Info` dictionary from a PDF file.
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {number=} options.firstPageToConvert - First page to print.
 	 * @param {number=} options.lastPageToConvert - Last page to print.
 	 * @param {boolean=} options.listEncodingOptions - List the available encodings.
@@ -340,7 +340,7 @@ class Poppler {
 	 * and writes one PDF file for each page to outputPattern.
 	 * This will not work if the file is encrypted.
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {number=} options.firstPageToExtract - Specifies the first page to extract.
 	 * This defaults to page 1.
 	 * @param {number=} options.lastPageToExtract - Specifies the last page to extract.
@@ -540,7 +540,7 @@ class Poppler {
 	 * Poppler will use the directory and name of the original file
 	 * and append `-html` to the end of the filename.
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {boolean=} options.complexOutput - Generate complex output.
 	 * @param {boolean=} options.exchangePdfLinks - Exchange .pdf links with .html.
 	 * @param {boolean=} options.extractHidden - Force hidden text extraction.
@@ -729,7 +729,7 @@ class Poppler {
 	 * @author Frazer Smith
 	 * @description Converts a PDF file to PostScript (PS).
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {('yes'|'no')=} options.antialias - Enable anti-aliasing on rasterization, accepts `yes` or `no`.
 	 * @param {boolean=} options.binary - Write binary data in Level 1 PostScript. By default,
 	 * pdftops writes hex-encoded data in Level 1 PostScript. Binary data is non-standard in Level 1
@@ -889,7 +889,7 @@ class Poppler {
 	 * @author Frazer Smith
 	 * @description Converts a PDF file to TXT.
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {boolean=} options.boundingBoxXhtml - Generate an XHTML file containing bounding
 	 * box information for each word in the file.
 	 * @param {boolean=} options.boundingBoxXhtmlLayout - Generate an XHTML file containing
@@ -983,7 +983,7 @@ class Poppler {
 	 * @description Merges several PDF files in order of their occurrence in the files array to
 	 * one PDF result file.
 	 *
-	 * @param {object=} options - Object containing options to pass to binary.
+	 * @param {object} options - Object containing options to pass to binary.
 	 * @param {boolean=} options.printVersionInfo - Print copyright and version information.
 	 * @param {Array} files - Filepaths of the PDF files to merge.
 	 * An entire directory of PDF files can be merged like so: `path/to/directory/*.pdf`.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"include": ["src/index.js"],
+	"compilerOptions": {
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"allowJs": true
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5581,6 +5581,11 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
+typescript@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
+  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+
 typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"


### PR DESCRIPTION
Hi! 👋 

This PR closes #149 by using TypeScript to generate the definition for the library from the JSDoc.

In order for the `options` to be generated correctly, we need to use `{object} options`, otherwise, TypeScript will declare the `options` as `object`.

Since `yarn doc` is part of the release process, I've added the `tsc` command to it.

Let me know your thoughts and if any of these changes are incorrect.

PS: I wasn't sure if you'd like to have the definition added through this PR or when releasing a new version, that's why I didn't commit it.

Last, if you enjoy this PR, I'd appreciate it if you can label it for Hacktoberfest with `hacktoberfest-accepted` 😄 