### PR TITLE
feat(index)!: add outputFile param to pdfToHtml() function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
 				max: 1,
 			},
 		],
+		"jsdoc/tag-lines": "off",
 		"prefer-destructuring": "off",
 		"promise/prefer-await-to-callbacks": "warn",
 		"promise/prefer-await-to-then": "warn",

--- a/API.md
+++ b/API.md
@@ -28,7 +28,7 @@ version of binary.</p>
     * [.pdfInfo(file, [options])](#Poppler+pdfInfo) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
     * [.pdfSeparate(file, outputPattern, [options])](#Poppler+pdfSeparate) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
     * [.pdfToCairo(file, [outputFile], [options])](#Poppler+pdfToCairo) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
-    * [.pdfToHtml(file, [options])](#Poppler+pdfToHtml) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
+    * [.pdfToHtml(file, [outputFile], [options])](#Poppler+pdfToHtml) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
     * [.pdfToPpm(file, outputPath, [options])](#Poppler+pdfToPpm) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
     * [.pdfToPs(file, [outputFile], [options])](#Poppler+pdfToPs) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
     * [.pdfToText(file, [outputFile], [options])](#Poppler+pdfToText) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
@@ -243,10 +243,8 @@ Converts a PDF file to PNG/JPEG/TIFF/PDF/PS/EPS/SVG.
 
 <a name="Poppler+pdfToHtml"></a>
 
-### poppler.pdfToHtml(file, [options]) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
+### poppler.pdfToHtml(file, [outputFile], [options]) ⇒ <code>Promise.&lt;(string\|Error)&gt;</code>
 Converts a PDF file to HTML.
-Poppler will use the directory and name of the original file
-and append `-html` to the end of the filename.
 
 **Kind**: instance method of [<code>Poppler</code>](#Poppler)  
 **Returns**: <code>Promise.&lt;(string\|Error)&gt;</code> - Promise of stdout string on resolve, or Error object on rejection.  
@@ -255,6 +253,7 @@ and append `-html` to the end of the filename.
 | Param | Type | Description |
 | --- | --- | --- |
 | file | <code>Buffer</code> \| <code>string</code> | PDF file as Buffer, or filepath of the PDF file to read. |
+| [outputFile] | <code>string</code> | Filepath of the file to output the results to. If `undefined` then Poppler will use the directory and name of the original file and create a new file, with `-html` appended to the end of the filename. Required if `file` is a Buffer. |
 | [options] | <code>object</code> | Object containing options to pass to binary. |
 | [options.complexOutput] | <code>boolean</code> | Generate complex output. |
 | [options.dataUrls] | <code>boolean</code> | Use data URLs instead of external images in HTML. |

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -273,10 +273,14 @@ export class Poppler {
 	/**
 	 * @author Frazer Smith
 	 * @description Converts a PDF file to HTML.
-	 * Poppler will use the directory and name of the original file
-	 * and append `-html` to the end of the filename.
 	 *
 	 * @param {Buffer| string} file - PDF file as Buffer, or filepath of the PDF file to read.
+	 * @param {string=} outputFile - Filepath of the file to output the results to.
+	 * If `undefined` then Poppler will use the directory and name of the original file
+	 * and create a new file, with `-html` appended to the end of the filename.
+	 *
+	 * Required if `file` is a Buffer.
+	 *
 	 * @param {object=} options - Object containing options to pass to binary.
 	 * @param {boolean=} options.complexOutput - Generate complex output.
 	 * @param {boolean=} options.dataUrls -  Use data URLs instead of external images in HTML.
@@ -310,6 +314,7 @@ export class Poppler {
 	 */
 	pdfToHtml(
 		file: Buffer | string,
+		outputFile?: string | undefined,
 		options?: object | undefined
 	): Promise<string | Error>;
 	/**

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -630,9 +630,15 @@ describe("pdfToHtml Function", () => {
 		const poppler = new Poppler(testBinaryPath);
 		const attachmentFile = fs.readFileSync(file);
 
-		const res = await poppler.pdfInfo(attachmentFile);
+		const res = await poppler.pdfToHtml(
+			attachmentFile,
+			`${testDirectory}pdf_1.3_NHS_Constitution.html`
+		);
 
 		expect(typeof res).toBe("string");
+		expect(
+			fs.existsSync(`${testDirectory}pdf_1.3_NHS_Constitution.html`)
+		).toBe(true);
 	});
 
 	test("Should accept options and only process 2 pages of PDF file", async () => {
@@ -642,7 +648,7 @@ describe("pdfToHtml Function", () => {
 			lastPageToConvert: 2,
 		};
 
-		const res = await poppler.pdfToHtml(file, options);
+		const res = await poppler.pdfToHtml(file, undefined, options);
 
 		expect(typeof res).toBe("string");
 		expect(
@@ -677,7 +683,7 @@ describe("pdfToHtml Function", () => {
 		};
 
 		expect.assertions(1);
-		await poppler.pdfToHtml(file, options).catch((err) => {
+		await poppler.pdfToHtml(file, undefined, options).catch((err) => {
 			expect(err.message).toEqual(
 				"Invalid value type provided for option 'firstPageToConvert', expected number but received string; Invalid value type provided for option 'lastPageToConvert', expected number but received string"
 			);
@@ -691,7 +697,7 @@ describe("pdfToHtml Function", () => {
 		};
 
 		expect.assertions(1);
-		await poppler.pdfToHtml(file, options).catch((err) => {
+		await poppler.pdfToHtml(file, undefined, options).catch((err) => {
 			expect(err.message).toEqual(
 				"Invalid option provided 'middlePageToConvert'"
 			);


### PR DESCRIPTION
BREAKING CHANGE: optional `outputFile`string parameter for `pdfToHtml()` function has been added after `file`. `Poppler.pdfToHtml(file, options)` is now `Poppler.pdfToHtml(file, outputFile, options)`.