### PR TITLE
fix(index): throw new error not return it as returning leads to silent failures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ class Poppler {
 					break;
 
 				default:
-					return new Error(`${platform} is NOT supported.`);
+					throw new Error(`${platform} is NOT supported.`);
 			}
 
 			this.popplerPath = popplerPath;


### PR DESCRIPTION
Error should be thrown not returns as returning leads to silent failures which are difficult to track down.