### PR TITLE
fix(index): use `spawn` for larger stream results

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable security/detect-child-process */
 const camelCase = require("camelcase");
 const path = require("upath");
-const { execFile } = require("child_process");
+const { execFile, spawn } = require("child_process");
 const util = require("util");
 
 const execFileAsync = util.promisify(execFile);

--- a/src/index.js
+++ b/src/index.js
@@ -230,7 +230,7 @@ class Poppler {
 					args.push(file);
 				}
 
-				const child = execFile(
+				const child = spawn(
 					path.joinSafe(this.popplerPath, "pdffonts"),
 					args
 				);
@@ -331,7 +331,7 @@ class Poppler {
 					args.push(outputPrefix);
 				}
 
-				const child = execFile(
+				const child = spawn(
 					path.joinSafe(this.popplerPath, "pdfimages"),
 					args
 				);
@@ -732,7 +732,7 @@ class Poppler {
 					args.push("-");
 				}
 
-				const child = execFile(
+				const child = spawn(
 					path.joinSafe(this.popplerPath, "pdftocairo"),
 					args
 				);
@@ -876,7 +876,7 @@ class Poppler {
 					args.push(outputFile);
 				}
 
-				const child = execFile(
+				const child = spawn(
 					path.joinSafe(this.popplerPath, "pdftohtml"),
 					args
 				);
@@ -1084,7 +1084,7 @@ class Poppler {
 
 				args.push(outputPath);
 
-				const child = execFile(
+				const child = spawn(
 					path.joinSafe(this.popplerPath, "pdftoppm"),
 					args
 				);
@@ -1323,7 +1323,7 @@ class Poppler {
 					args.push("-");
 				}
 
-				const child = execFile(
+				const child = spawn(
 					path.joinSafe(this.popplerPath, "pdftops"),
 					args
 				);
@@ -1474,7 +1474,7 @@ class Poppler {
 					args.push("-");
 				}
 
-				const child = execFile(
+				const child = spawn(
 					path.joinSafe(this.popplerPath, "pdftotext"),
 					args
 				);


### PR DESCRIPTION
Well, I've been staring at my screen long enough trying to figure out an issue we are having, but it wasn't my code after all 😅 
It basically comes down to the `exec` command not returning all the data as `exec` is not suitable for big results:
https://stackoverflow.com/questions/48698234/node-js-spawn-vs-execute

I was having the problem with `pdfToCairo` in `singleFile` mode. It returned a string which size was just over 1.000.000 characters long, in other words, 1MB:

> maximum data transfer up to Node.js v.12.x was 200kb (by default), but since Node.js v.12x was increased to 1MB (by default)

I use Node 14, so that explains a lot.

This PR definitely fixes this problem. I'm just not sure if there's any particular reason you've used `exec` instead of `spawn`. An alternative would be something like the following:
```ts
const child = execFileAsync(
	path.joinSafe(this.popplerPath, "pdftocairo"),
	args,
	{maxBuffer: 1024 * 500000}
);
```

This increases the max buffer output to 50MB which should be sufficient in more cases I guess, but I think spawn is the much safer choice, what do you think?

I've only applied it to every method that gathers data from the `stdout` before returning the result.