### PR TITLE
fix(index): respect the value of boolean options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,8 @@ function parseOptions(acceptedOptions, options, version) {
 		if (Object.prototype.hasOwnProperty.call(acceptedOptions, key)) {
 			// eslint-disable-next-line valid-typeof
 			if (typeof options[key] === acceptedOptions[key].type) {
-				if (
-					typeof options[key] === "boolean" &&
-					options[key] === false
-				) {
+				// Skip boolean options if false
+				if (acceptedOptions[key].type === "boolean" && !options[key]) {
 					return;
 				}
 				// Arg will be empty for some non-standard options

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,12 @@ function parseOptions(acceptedOptions, options, version) {
 		if (Object.prototype.hasOwnProperty.call(acceptedOptions, key)) {
 			// eslint-disable-next-line valid-typeof
 			if (typeof options[key] === acceptedOptions[key].type) {
+				if (
+					typeof options[key] === "boolean" &&
+					options[key] === false
+				) {
+					return;
+				}
 				// Arg will be empty for some non-standard options
 				if (acceptedOptions[key].arg !== "") {
 					args.push(acceptedOptions[key].arg);


### PR DESCRIPTION
If an option is type of `boolean`, only provide it to binary executable as an argument when its value is `true`.