### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Example of an `async` `await` call to `poppler.pdfToCairo()`, to convert only th
 PDF file using stdout:
 
 ```js
-const fs = require("fs");
+const { writeFile } = require("node:fs/promises");
 const { Poppler } = require("node-poppler");
 
 const file = "test_document.pdf";
@@ -93,7 +93,7 @@ const options = {
 
 const res = await poppler.pdfToCairo(file, undefined, options);
 // pdfToCairo writes to stdout using binary encoding if pdfFile or singleFile options are used
-await fs.writeFile("new_file.pdf", res, { encoding: "binary" });
+await writeFile("new_file.pdf", res, { encoding: "binary" });
 ```
 
 ### poppler.pdfToHtml
@@ -118,10 +118,10 @@ poppler.pdfToHtml(file, undefined, options).then((res) => {
 Example of calling `poppler.pdfToHtml()` with a promise chain, providing a Buffer as an input:
 
 ```js
-const fs = require("fs");
+const { readFileSync } = require("node:fs");
 const { Poppler } = require("node-poppler");
 
-const file = fs.readFileSync("test_document.pdf");
+const file = readFileSync("test_document.pdf");
 const poppler = new Poppler();
 const options = {
 	firstPageToConvert: 1,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 	"author": "Frazer Smith <frazer.dev@outlook.com>",
 	"funding": "https://github.com/sponsors/Fdawgs",
 	"engines": {
-		"node": ">=14.0.0"
+		"node": ">=14.18.0"
 	},
 	"scripts": {
 		"build": "tsc && jsdoc2md src/index.js > API.md && npm run lint:prettier:fix",

--- a/scripts/license-checker.js
+++ b/scripts/license-checker.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const { promisify } = require("util");
+const { promisify } = require("node:util");
 const { init } = require("license-checker");
 // @ts-ignore
 const copyLeftLicenses = require("spdx-copyleft");

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
-const { execFile, spawn } = require("child_process");
-const { promisify } = require("util");
+const { execFile, spawn } = require("node:child_process");
+const { promisify } = require("node:util");
 const camelCase = require("camelcase");
 const { lt } = require("semver");
 const path = require("upath");

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,9 +3,9 @@
 
 "use strict";
 
-const { execFile } = require("child_process");
-const { access, readFile, unlink } = require("fs/promises");
-const { promisify } = require("util");
+const { execFile } = require("node:child_process");
+const { access, readFile, unlink } = require("node:fs/promises");
+const { promisify } = require("node:util");
 const { glob } = require("glob");
 const { lt } = require("semver");
 const path = require("upath");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
 		"declaration": true,
 		"emitDeclarationOnly": true,
 		"lib": ["ES2019"],
-		"moduleResolution": "nodenext",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
 		"outDir": "types",
 		"resolveJsonModule": true,
 		"strict": true


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/37246/files#r588397158