### PR TITLE
Add support for streams as input- and/or output from poppler.pdfToCairo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,2 @@
 # Set default behaviour to automatically convert line endings
-* text=auto
-
-# Require Unix line endings
-* text eol=lf
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,7 @@ updates:
       ignore:
           # Below are deps that have migrate to ESM in their
           # next major version so we can't use them
+          - dependency-name: is-stream
           - dependency-name: camelcase
             update-types: ["version-update:semver-major"]
       open-pull-requests-limit: 20

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 	},
 	"dependencies": {
 		"camelcase": "^6.3.0",
+		"is-stream": "^2.0.1",
 		"semver": "^7.5.4",
 		"upath": "^2.0.1"
 	}


### PR DESCRIPTION
## Add support for streams as input- and/or output from poppler.pdfToCairo

### The concept
**inputFile** can now be a ReadableStream or a buffer (as before)
**outputFile** can now be a WritableStream or a file path (as before)

If inputFile is a stream, **inputFile** will be piped into **stdin**
If outputFile is a stream **stdout** will be piped into **outputFile**
Result from the function behaves as before, i.e. a promise which resolves to "No Error" if everything is ok.

The same concept could be applied to all single-file conversions (pdfToHtml, etc), but I only need pdfToCairo for now. If you like this PR, I can apply this concept to pdfToHtml, pdfToPpm, pdfToPs, pdfToText as well.

### Tasks
Added stream support to pdfToCairo
Added test for streams
Updated .gitattribute to solve some Windows/Mac problem with CRLF/LF
Stream example added to README
Test suite now finds binaryPath even if installed with Homebrew
Tests passes, ESLint passes.