### PR TITLE
docs(readme): clarify the first page of the PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const res = await poppler.pdfToCairo(file, outputFile, options);
 console.log(res);
 ```
 
-Example of an `async` `await` call to `poppler.pdfToCairo()`, to convert only the first of a PDF file to a new
+Example of an `async` `await` call to `poppler.pdfToCairo()`, to convert only the first page of a PDF file to a new
 PDF file using stdout:
 
 ```js


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)

I added the word `page` to clarify that only the first page of the PDF file is being converted.