### PR TITLE
perf(index): use `for` loop over `for...of` loop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,10 @@ function parseOptions(acceptedOptions, options, version) {
 	const args = [];
 	/** @type {string[]} */
 	const invalidArgs = [];
-	for (const key of Object.keys(options)) {
+	const keys = Object.keys(options);
+	const keysLength = keys.length;
+	for (let i = 0; i < keysLength; i += 1) {
+		const key = keys[i];
 		if (Object.hasOwn(acceptedOptions, key)) {
 			const option = options[key];
 			const acceptedOption = acceptedOptions[key];


### PR DESCRIPTION
`for...of` [has an iterator overhead](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of#description).

A traditional loop is faster because there are no intermediate objects created or function calls during iteration.
With the length being cached, there are no property lookups either.

See https://github.com/kibertoad/nodejs-benchmark-tournament for supporting benchmarking.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
