### PR TITLE
perf(index): cache `acceptedOptions` only on first call, not on init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -120,335 +120,7 @@ class Poppler {
 	#pdfUniteBin;
 
 	#binVersions = new Map();
-
-	/** @type {Record<string, PopplerAcceptedOptions>} */
-	static #acceptedOptions = {
-		pdfAttach: {
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			replace: { arg: "-replace", type: "boolean" },
-		},
-		pdfDetach: {
-			listEmbedded: { arg: "-list", type: "boolean" },
-			outputEncoding: { arg: "-enc", type: "string" },
-			outputPath: { arg: "-o", type: "string" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			saveAllFiles: { arg: "-saveall", type: "boolean" },
-			saveFile: {
-				arg: "-savefile",
-				type: "string",
-				minVersion: "0.86.0",
-			},
-			saveSpecificFile: { arg: "-save", type: "number" },
-			userPassword: { arg: "-upw", type: "string" },
-		},
-		pdfFonts: {
-			firstPageToExamine: { arg: "-f", type: "number" },
-			lastPageToExamine: { arg: "-l", type: "number" },
-			listSubstitutes: { arg: "-subst", type: "boolean" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			userPassword: { arg: "-upw", type: "string" },
-		},
-		pdfImages: {
-			allFiles: { arg: "-all", type: "boolean" },
-			ccittFile: { arg: "-ccitt", type: "boolean" },
-			firstPageToConvert: { arg: "-f", type: "number" },
-			lastPageToConvert: { arg: "-l", type: "number" },
-			jbig2File: { arg: "-jbig2", type: "boolean" },
-			jpeg2000File: { arg: "-jp2", type: "boolean" },
-			jpegFile: { arg: "-j", type: "boolean" },
-			list: { arg: "-list", type: "boolean" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			pngFile: { arg: "-png", type: "boolean" },
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			tiffFile: { arg: "-tiff", type: "boolean" },
-			userPassword: { arg: "-upw", type: "string" },
-		},
-		pdfInfo: {
-			firstPageToConvert: { arg: "-f", type: "number" },
-			lastPageToConvert: { arg: "-l", type: "number" },
-			listEncodingOptions: { arg: "-listenc", type: "boolean" },
-			outputEncoding: { arg: "-enc", type: "string" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			printAsJson: { arg: "", type: "boolean" },
-			printBoundingBoxes: { arg: "-box", type: "boolean" },
-			printDocStruct: { arg: "-struct", type: "boolean" },
-			printDocStructText: { arg: "-struct-text", type: "boolean" },
-			printIsoDates: { arg: "-isodates", type: "boolean" },
-			printJS: { arg: "-js", type: "boolean" },
-			printMetadata: { arg: "-meta", type: "boolean" },
-			printNamedDests: { arg: "-dests", type: "boolean" },
-			printRawDates: { arg: "-rawdates", type: "boolean" },
-			printUrls: { arg: "-url", type: "boolean", minVersion: "21.11.0" },
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			userPassword: { arg: "-upw", type: "string" },
-		},
-		pdfSeparate: {
-			firstPageToExtract: { arg: "-f", type: "number" },
-			lastPageToExtract: { arg: "-l", type: "number" },
-			printVersionInfo: { arg: "-v", type: "boolean" },
-		},
-		pdfToCairo: {
-			antialias: { arg: "-antialias", type: "string" },
-			cropBox: { arg: "-cropbox", type: "boolean" },
-			cropHeight: { arg: "-H", type: "number" },
-			cropSize: { arg: "-sz", type: "number" },
-			cropWidth: { arg: "-W", type: "number" },
-			cropXAxis: { arg: "-x", type: "number" },
-			cropYAxis: { arg: "-y", type: "number" },
-			duplex: { arg: "-duplex", type: "boolean" },
-			epsFile: { arg: "-eps", type: "boolean" },
-			evenPagesOnly: { arg: "-e", type: "boolean" },
-			fillPage: { arg: "-expand", type: "boolean" },
-			firstPageToConvert: { arg: "-f", type: "number" },
-			grayscaleFile: { arg: "-gray", type: "boolean" },
-			iccFile: { arg: "-icc", type: "string" },
-			jpegFile: { arg: "-jpeg", type: "boolean" },
-			jpegOptions: { arg: "-jpegopt", type: "string" },
-			lastPageToConvert: { arg: "-l", type: "number" },
-			monochromeFile: { arg: "-mono", type: "boolean" },
-			noCenter: { arg: "-nocenter", type: "boolean" },
-			noCrop: { arg: "-nocrop", type: "boolean" },
-			noShrink: { arg: "-noshrink", type: "boolean" },
-			oddPagesOnly: { arg: "-o", type: "boolean" },
-			originalPageSizes: { arg: "-origpagesizes", type: "boolean" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			paperHeight: { arg: "-paperh", type: "number" },
-			paperSize: { arg: "-paper", type: "string" },
-			paperWidth: { arg: "-paperw", type: "number" },
-			pdfFile: { arg: "-pdf", type: "boolean" },
-			pngFile: { arg: "-png", type: "boolean" },
-			printDocStruct: {
-				arg: "-struct",
-				type: "boolean",
-				minVersion: "23.11.0",
-			},
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			psFile: { arg: "-ps", type: "boolean" },
-			psLevel2: { arg: "-level2", type: "boolean" },
-			psLevel3: { arg: "-level3", type: "boolean" },
-			quiet: { arg: "-q", type: "boolean" },
-			resolutionXAxis: { arg: "-rx", type: "number" },
-			resolutionXYAxis: { arg: "-r", type: "number" },
-			resolutionYAxis: { arg: "-ry", type: "number" },
-			scalePageTo: { arg: "-scale-to", type: "number" },
-			scalePageToXAxis: { arg: "-scale-to-x", type: "number" },
-			scalePageToYAxis: { arg: "-scale-to-y", type: "number" },
-			singleFile: { arg: "-singlefile", type: "boolean" },
-			svgFile: { arg: "-svg", type: "boolean" },
-			tiffCompression: { arg: "-tiffcompression", type: "string" },
-			tiffFile: { arg: "-tiff", type: "boolean" },
-			transparentPageColor: { arg: "-transp", type: "boolean" },
-			userPassword: { arg: "-upw", type: "string" },
-		},
-		pdfToHtml: {
-			complexOutput: { arg: "-c", type: "boolean" },
-			dataUrls: {
-				arg: "-dataurls",
-				type: "boolean",
-				minVersion: "0.75.0",
-			},
-			exchangePdfLinks: { arg: "-p", type: "boolean" },
-			extractHidden: { arg: "-hidden", type: "boolean" },
-			firstPageToConvert: { arg: "-f", type: "number" },
-			fontFullName: { arg: "-fontfullname", type: "boolean" },
-			ignoreImages: { arg: "-i", type: "boolean" },
-			imageFormat: { arg: "-fmt", type: "string" },
-			lastPageToConvert: { arg: "-l", type: "number" },
-			noDrm: { arg: "-nodrm", type: "boolean" },
-			noFrames: { arg: "-noframes", type: "boolean" },
-			noMergeParagraph: { arg: "-nomerge", type: "boolean" },
-			noRoundedCoordinates: { arg: "-noroundcoord", type: "boolean" },
-			outputEncoding: { arg: "-enc", type: "string" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			quiet: { arg: "-q", type: "boolean" },
-			singlePage: { arg: "-s", type: "boolean" },
-			stdout: { arg: "-stdout", type: "boolean" },
-			userPassword: { arg: "-upw", type: "string" },
-			wordBreakThreshold: { arg: "-wbt", type: "number" },
-			xmlOutput: { arg: "-xml", type: "boolean" },
-			zoom: { arg: "-zoom", type: "number" },
-		},
-		pdfToPpm: {
-			antialiasFonts: { arg: "-aa", type: "string" },
-			antialiasVectors: { arg: "-aaVector", type: "string" },
-			cropBox: { arg: "-cropbox", type: "boolean" },
-			cropHeight: { arg: "-H", type: "number" },
-			cropSize: { arg: "-sz", type: "number" },
-			cropWidth: { arg: "-W", type: "number" },
-			cropXAxis: { arg: "-x", type: "number" },
-			cropYAxis: { arg: "-y", type: "number" },
-			defaultCmykProfile: {
-				arg: "-defaultcmykprofile",
-				type: "string",
-				minVersion: "21.01.0",
-			},
-			defaultGrayProfile: {
-				arg: "-defaultgrayprofile",
-				type: "string",
-				minVersion: "21.01.0",
-			},
-			defaultRgbProfile: {
-				arg: "-defaultrgbprofile",
-				type: "string",
-				minVersion: "21.01.0",
-			},
-			displayProfile: {
-				arg: "-displayprofile",
-				type: "string",
-				minVersion: "0.90.0",
-			},
-			evenPagesOnly: { arg: "-e", type: "boolean" },
-			firstPageToConvert: { arg: "-f", type: "number" },
-			forcePageNumber: {
-				arg: "-forcenum",
-				type: "boolean",
-				minVersion: "0.75.0",
-			},
-			freetype: { arg: "-freetype", type: "string" },
-			grayscaleFile: { arg: "-gray", type: "boolean" },
-			hideAnnotations: {
-				arg: "-hide-annotations",
-				type: "boolean",
-				minVersion: "0.84.0",
-			},
-			jpegFile: { arg: "-jpeg", type: "boolean" },
-			lastPageToConvert: { arg: "-l", type: "number" },
-			monochromeFile: { arg: "-mono", type: "boolean" },
-			oddPagesOnly: { arg: "-o", type: "boolean" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			pngFile: { arg: "-png", type: "boolean" },
-			printProgress: {
-				arg: "-progress",
-				type: "boolean",
-				minVersion: "21.03.0",
-			},
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			quiet: { arg: "-q", type: "boolean" },
-			resolutionXAxis: { arg: "-rx", type: "number" },
-			resolutionXYAxis: { arg: "-r", type: "number" },
-			resolutionYAxis: { arg: "-ry", type: "number" },
-			scalePageTo: { arg: "-scale-to", type: "number" },
-			scalePageToXAxis: { arg: "-scale-to-x", type: "number" },
-			scalePageToYAxis: { arg: "-scale-to-y", type: "number" },
-			separator: { arg: "-sep", type: "string", minVersion: "0.75.0" },
-			singleFile: { arg: "-singlefile", type: "boolean" },
-			thinLineMode: { arg: "-thinlinemode", type: "string" },
-			tiffCompression: { arg: "-tiffcompression", type: "string" },
-			tiffFile: { arg: "-tiff", type: "boolean" },
-			userPassword: { arg: "-upw", type: "string" },
-		},
-		pdfToPs: {
-			antialias: { arg: "-aaRaster", type: "string" },
-			binary: { arg: "-binary", type: "boolean" },
-			defaultCmykProfile: {
-				arg: "-defaultcmykprofile",
-				type: "string",
-				minVersion: "21.01.0",
-			},
-			defaultGrayProfile: {
-				arg: "-defaultgrayprofile",
-				type: "string",
-				minVersion: "21.01.0",
-			},
-			defaultRgbProfile: {
-				arg: "-defaultrgbprofile",
-				type: "string",
-				minVersion: "21.01.0",
-			},
-			duplex: { arg: "-duplex", type: "boolean" },
-			epsFile: { arg: "-eps", type: "boolean" },
-			fillPage: { arg: "-expand", type: "boolean" },
-			firstPageToConvert: { arg: "-f", type: "number" },
-			form: { arg: "-form", type: "boolean" },
-			lastPageToConvert: { arg: "-l", type: "number" },
-			level1: { arg: "-level1", type: "boolean" },
-			level1Sep: { arg: "-level1sep", type: "boolean" },
-			level2: { arg: "-level2", type: "boolean" },
-			level2Sep: { arg: "-level2sep", type: "boolean" },
-			level3: { arg: "-level3", type: "boolean" },
-			level3Sep: { arg: "-level3sep", type: "boolean" },
-			noCenter: { arg: "-nocenter", type: "boolean" },
-			noCrop: { arg: "-nocrop", type: "boolean" },
-			noEmbedCIDFonts: { arg: "-noembcidps", type: "boolean" },
-			noEmbedCIDTrueTypeFonts: {
-				arg: "-noembcidtt",
-				type: "boolean",
-			},
-			noEmbedTrueTypeFonts: { arg: "-noembtt", type: "boolean" },
-			noEmbedType1Fonts: { arg: "-noembt1", type: "boolean" },
-			noShrink: { arg: "-noshrink", type: "boolean" },
-			opi: { arg: "-opi", type: "boolean" },
-			optimizecolorspace: {
-				arg: "-optimizecolorspace",
-				type: "boolean",
-			},
-			originalPageSizes: { arg: "-origpagesizes", type: "boolean" },
-			overprint: { arg: "-overprint", type: "boolean" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			paperHeight: { arg: "-paperh", type: "number" },
-			paperSize: { arg: "-paper", type: "string" },
-			paperWidth: { arg: "-paperw", type: "number" },
-			passfonts: { arg: "-passfonts", type: "boolean" },
-			preload: { arg: "-preload", type: "boolean" },
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			processColorFormat: { arg: "-processcolorformat", type: "string" },
-			processColorProfile: {
-				arg: "-processcolorprofile",
-				type: "string",
-			},
-			quiet: { arg: "-q", type: "boolean" },
-			rasterize: {
-				arg: "-rasterize",
-				type: "string",
-				minVersion: "0.90.0",
-			},
-			resolutionXYAxis: { arg: "-r", type: "number" },
-			userPassword: { arg: "-upw", type: "string" },
-		},
-		pdfToText: {
-			boundingBoxXhtml: { arg: "-bbox", type: "boolean" },
-			boundingBoxXhtmlLayout: {
-				arg: "-bbox-layout",
-				type: "boolean",
-			},
-			cropBox: {
-				arg: "-cropbox",
-				type: "boolean",
-				minVersion: "21.03.0",
-			},
-			cropHeight: { arg: "-H", type: "number" },
-			cropWidth: { arg: "-W", type: "number" },
-			cropXAxis: { arg: "-x", type: "number" },
-			cropYAxis: { arg: "-y", type: "number" },
-			eolConvention: { arg: "-eol", type: "string" },
-			firstPageToConvert: { arg: "-f", type: "number" },
-			fixedWidthLayout: { arg: "-fixed", type: "number" },
-			generateHtmlMetaFile: { arg: "-htmlmeta", type: "boolean" },
-			generateTsvFile: { arg: "-tsv", type: "boolean" },
-			lastPageToConvert: { arg: "-l", type: "number" },
-			listEncodingOptions: { arg: "-listenc", type: "boolean" },
-			maintainLayout: { arg: "-layout", type: "boolean" },
-			noDiagonalText: {
-				arg: "-nodiag",
-				type: "boolean",
-				minVersion: "0.80.0",
-			},
-			noPageBreaks: { arg: "-nopgbrk", type: "boolean" },
-			outputEncoding: { arg: "-enc", type: "string" },
-			ownerPassword: { arg: "-opw", type: "string" },
-			printVersionInfo: { arg: "-v", type: "boolean" },
-			quiet: { arg: "-q", type: "boolean" },
-			rawLayout: { arg: "-raw", type: "boolean" },
-			resolution: { arg: "-r", type: "number" },
-			userPassword: { arg: "-upw", type: "string" },
-		},
-		pdfUnite: {
-			printVersionInfo: { arg: "-v", type: "boolean" },
-		},
-	};
+	#acceptedOptions = new Map();
 
 	/**
 	 * @param {string} [binPath] - Path of poppler-utils binaries.
@@ -533,6 +205,429 @@ class Poppler {
 
 	/**
 	 * @author Frazer Smith
+	 * @description Returns the accepted options for the specified Poppler binary function.
+	 * @param {string} functionName - The name of the Poppler binary function.
+	 * @returns {PopplerAcceptedOptions} An object containing the accepted options of the specified function.
+	 */
+	#getAcceptedOptions(functionName) {
+		if (!this.#acceptedOptions.has(functionName)) {
+			switch (functionName) {
+				case "pdfAttach":
+					this.#acceptedOptions.set("pdfAttach", {
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						replace: { arg: "-replace", type: "boolean" },
+					});
+					break;
+				case "pdfDetach":
+					this.#acceptedOptions.set("pdfDetach", {
+						listEmbedded: { arg: "-list", type: "boolean" },
+						outputEncoding: { arg: "-enc", type: "string" },
+						outputPath: { arg: "-o", type: "string" },
+						ownerPassword: { arg: "-opw", type: "string" },
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						saveAllFiles: { arg: "-saveall", type: "boolean" },
+						saveFile: {
+							arg: "-savefile",
+							type: "string",
+							minVersion: "0.86.0",
+						},
+						saveSpecificFile: { arg: "-save", type: "number" },
+						userPassword: { arg: "-upw", type: "string" },
+					});
+					break;
+				case "pdfFonts":
+					this.#acceptedOptions.set("pdfFonts", {
+						firstPageToExamine: { arg: "-f", type: "number" },
+						lastPageToExamine: { arg: "-l", type: "number" },
+						listSubstitutes: { arg: "-subst", type: "boolean" },
+						ownerPassword: { arg: "-opw", type: "string" },
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						userPassword: { arg: "-upw", type: "string" },
+					});
+					break;
+				case "pdfImages":
+					this.#acceptedOptions.set("pdfImages", {
+						allFiles: { arg: "-all", type: "boolean" },
+						ccittFile: { arg: "-ccitt", type: "boolean" },
+						firstPageToConvert: { arg: "-f", type: "number" },
+						lastPageToConvert: { arg: "-l", type: "number" },
+						jbig2File: { arg: "-jbig2", type: "boolean" },
+						jpeg2000File: { arg: "-jp2", type: "boolean" },
+						jpegFile: { arg: "-j", type: "boolean" },
+						list: { arg: "-list", type: "boolean" },
+						ownerPassword: { arg: "-opw", type: "string" },
+						pngFile: { arg: "-png", type: "boolean" },
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						tiffFile: { arg: "-tiff", type: "boolean" },
+						userPassword: { arg: "-upw", type: "string" },
+					});
+					break;
+				case "pdfInfo":
+					this.#acceptedOptions.set("pdfInfo", {
+						firstPageToConvert: { arg: "-f", type: "number" },
+						lastPageToConvert: { arg: "-l", type: "number" },
+						listEncodingOptions: {
+							arg: "-listenc",
+							type: "boolean",
+						},
+						outputEncoding: { arg: "-enc", type: "string" },
+						ownerPassword: { arg: "-opw", type: "string" },
+						printAsJson: { arg: "", type: "boolean" },
+						printBoundingBoxes: { arg: "-box", type: "boolean" },
+						printDocStruct: { arg: "-struct", type: "boolean" },
+						printDocStructText: {
+							arg: "-struct-text",
+							type: "boolean",
+						},
+						printIsoDates: { arg: "-isodates", type: "boolean" },
+						printJS: { arg: "-js", type: "boolean" },
+						printMetadata: { arg: "-meta", type: "boolean" },
+						printNamedDests: { arg: "-dests", type: "boolean" },
+						printRawDates: { arg: "-rawdates", type: "boolean" },
+						printUrls: {
+							arg: "-url",
+							type: "boolean",
+							minVersion: "21.11.0",
+						},
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						userPassword: { arg: "-upw", type: "string" },
+					});
+					break;
+				case "pdfSeparate":
+					this.#acceptedOptions.set("pdfSeparate", {
+						firstPageToExtract: { arg: "-f", type: "number" },
+						lastPageToExtract: { arg: "-l", type: "number" },
+						printVersionInfo: { arg: "-v", type: "boolean" },
+					});
+					break;
+				case "pdfToCairo":
+					this.#acceptedOptions.set("pdfToCairo", {
+						antialias: { arg: "-antialias", type: "string" },
+						cropBox: { arg: "-cropbox", type: "boolean" },
+						cropHeight: { arg: "-H", type: "number" },
+						cropSize: { arg: "-sz", type: "number" },
+						cropWidth: { arg: "-W", type: "number" },
+						cropXAxis: { arg: "-x", type: "number" },
+						cropYAxis: { arg: "-y", type: "number" },
+						duplex: { arg: "-duplex", type: "boolean" },
+						epsFile: { arg: "-eps", type: "boolean" },
+						evenPagesOnly: { arg: "-e", type: "boolean" },
+						fillPage: { arg: "-expand", type: "boolean" },
+						firstPageToConvert: { arg: "-f", type: "number" },
+						grayscaleFile: { arg: "-gray", type: "boolean" },
+						iccFile: { arg: "-icc", type: "string" },
+						jpegFile: { arg: "-jpeg", type: "boolean" },
+						jpegOptions: { arg: "-jpegopt", type: "string" },
+						lastPageToConvert: { arg: "-l", type: "number" },
+						monochromeFile: { arg: "-mono", type: "boolean" },
+						noCenter: { arg: "-nocenter", type: "boolean" },
+						noCrop: { arg: "-nocrop", type: "boolean" },
+						noShrink: { arg: "-noshrink", type: "boolean" },
+						oddPagesOnly: { arg: "-o", type: "boolean" },
+						originalPageSizes: {
+							arg: "-origpagesizes",
+							type: "boolean",
+						},
+						ownerPassword: { arg: "-opw", type: "string" },
+						paperHeight: { arg: "-paperh", type: "number" },
+						paperSize: { arg: "-paper", type: "string" },
+						paperWidth: { arg: "-paperw", type: "number" },
+						pdfFile: { arg: "-pdf", type: "boolean" },
+						pngFile: { arg: "-png", type: "boolean" },
+						printDocStruct: {
+							arg: "-struct",
+							type: "boolean",
+							minVersion: "23.11.0",
+						},
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						psFile: { arg: "-ps", type: "boolean" },
+						psLevel2: { arg: "-level2", type: "boolean" },
+						psLevel3: { arg: "-level3", type: "boolean" },
+						quiet: { arg: "-q", type: "boolean" },
+						resolutionXAxis: { arg: "-rx", type: "number" },
+						resolutionXYAxis: { arg: "-r", type: "number" },
+						resolutionYAxis: { arg: "-ry", type: "number" },
+						scalePageTo: { arg: "-scale-to", type: "number" },
+						scalePageToXAxis: {
+							arg: "-scale-to-x",
+							type: "number",
+						},
+						scalePageToYAxis: {
+							arg: "-scale-to-y",
+							type: "number",
+						},
+						singleFile: { arg: "-singlefile", type: "boolean" },
+						svgFile: { arg: "-svg", type: "boolean" },
+						tiffCompression: {
+							arg: "-tiffcompression",
+							type: "string",
+						},
+						tiffFile: { arg: "-tiff", type: "boolean" },
+						transparentPageColor: {
+							arg: "-transp",
+							type: "boolean",
+						},
+						userPassword: { arg: "-upw", type: "string" },
+					});
+					break;
+				case "pdfToHtml":
+					this.#acceptedOptions.set("pdfToHtml", {
+						complexOutput: { arg: "-c", type: "boolean" },
+						dataUrls: {
+							arg: "-dataurls",
+							type: "boolean",
+							minVersion: "0.75.0",
+						},
+						exchangePdfLinks: { arg: "-p", type: "boolean" },
+						extractHidden: { arg: "-hidden", type: "boolean" },
+						firstPageToConvert: { arg: "-f", type: "number" },
+						fontFullName: { arg: "-fontfullname", type: "boolean" },
+						ignoreImages: { arg: "-i", type: "boolean" },
+						imageFormat: { arg: "-fmt", type: "string" },
+						lastPageToConvert: { arg: "-l", type: "number" },
+						noDrm: { arg: "-nodrm", type: "boolean" },
+						noFrames: { arg: "-noframes", type: "boolean" },
+						noMergeParagraph: { arg: "-nomerge", type: "boolean" },
+						noRoundedCoordinates: {
+							arg: "-noroundcoord",
+							type: "boolean",
+						},
+						outputEncoding: { arg: "-enc", type: "string" },
+						ownerPassword: { arg: "-opw", type: "string" },
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						quiet: { arg: "-q", type: "boolean" },
+						singlePage: { arg: "-s", type: "boolean" },
+						stdout: { arg: "-stdout", type: "boolean" },
+						userPassword: { arg: "-upw", type: "string" },
+						wordBreakThreshold: { arg: "-wbt", type: "number" },
+						xmlOutput: { arg: "-xml", type: "boolean" },
+						zoom: { arg: "-zoom", type: "number" },
+					});
+					break;
+				case "pdfToPpm":
+					this.#acceptedOptions.set("pdfToPpm", {
+						antialiasFonts: { arg: "-aa", type: "string" },
+						antialiasVectors: { arg: "-aaVector", type: "string" },
+						cropBox: { arg: "-cropbox", type: "boolean" },
+						cropHeight: { arg: "-H", type: "number" },
+						cropSize: { arg: "-sz", type: "number" },
+						cropWidth: { arg: "-W", type: "number" },
+						cropXAxis: { arg: "-x", type: "number" },
+						cropYAxis: { arg: "-y", type: "number" },
+						defaultCmykProfile: {
+							arg: "-defaultcmykprofile",
+							type: "string",
+							minVersion: "21.01.0",
+						},
+						defaultGrayProfile: {
+							arg: "-defaultgrayprofile",
+							type: "string",
+							minVersion: "21.01.0",
+						},
+						defaultRgbProfile: {
+							arg: "-defaultrgbprofile",
+							type: "string",
+							minVersion: "21.01.0",
+						},
+						displayProfile: {
+							arg: "-displayprofile",
+							type: "string",
+							minVersion: "0.90.0",
+						},
+						evenPagesOnly: { arg: "-e", type: "boolean" },
+						firstPageToConvert: { arg: "-f", type: "number" },
+						forcePageNumber: {
+							arg: "-forcenum",
+							type: "boolean",
+							minVersion: "0.75.0",
+						},
+						freetype: { arg: "-freetype", type: "string" },
+						grayscaleFile: { arg: "-gray", type: "boolean" },
+						hideAnnotations: {
+							arg: "-hide-annotations",
+							type: "boolean",
+							minVersion: "0.84.0",
+						},
+						jpegFile: { arg: "-jpeg", type: "boolean" },
+						lastPageToConvert: { arg: "-l", type: "number" },
+						monochromeFile: { arg: "-mono", type: "boolean" },
+						oddPagesOnly: { arg: "-o", type: "boolean" },
+						ownerPassword: { arg: "-opw", type: "string" },
+						pngFile: { arg: "-png", type: "boolean" },
+						printProgress: {
+							arg: "-progress",
+							type: "boolean",
+							minVersion: "21.03.0",
+						},
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						quiet: { arg: "-q", type: "boolean" },
+						resolutionXAxis: { arg: "-rx", type: "number" },
+						resolutionXYAxis: { arg: "-r", type: "number" },
+						resolutionYAxis: { arg: "-ry", type: "number" },
+						scalePageTo: { arg: "-scale-to", type: "number" },
+						scalePageToXAxis: {
+							arg: "-scale-to-x",
+							type: "number",
+						},
+						scalePageToYAxis: {
+							arg: "-scale-to-y",
+							type: "number",
+						},
+						separator: {
+							arg: "-sep",
+							type: "string",
+							minVersion: "0.75.0",
+						},
+						singleFile: { arg: "-singlefile", type: "boolean" },
+						thinLineMode: { arg: "-thinlinemode", type: "string" },
+						tiffCompression: {
+							arg: "-tiffcompression",
+							type: "string",
+						},
+						tiffFile: { arg: "-tiff", type: "boolean" },
+						userPassword: { arg: "-upw", type: "string" },
+					});
+					break;
+				case "pdfToPs":
+					this.#acceptedOptions.set("pdfToPs", {
+						antialias: { arg: "-aaRaster", type: "string" },
+						binary: { arg: "-binary", type: "boolean" },
+						defaultCmykProfile: {
+							arg: "-defaultcmykprofile",
+							type: "string",
+							minVersion: "21.01.0",
+						},
+						defaultGrayProfile: {
+							arg: "-defaultgrayprofile",
+							type: "string",
+							minVersion: "21.01.0",
+						},
+						defaultRgbProfile: {
+							arg: "-defaultrgbprofile",
+							type: "string",
+							minVersion: "21.01.0",
+						},
+						duplex: { arg: "-duplex", type: "boolean" },
+						epsFile: { arg: "-eps", type: "boolean" },
+						fillPage: { arg: "-expand", type: "boolean" },
+						firstPageToConvert: { arg: "-f", type: "number" },
+						form: { arg: "-form", type: "boolean" },
+						lastPageToConvert: { arg: "-l", type: "number" },
+						level1: { arg: "-level1", type: "boolean" },
+						level1Sep: { arg: "-level1sep", type: "boolean" },
+						level2: { arg: "-level2", type: "boolean" },
+						level2Sep: { arg: "-level2sep", type: "boolean" },
+						level3: { arg: "-level3", type: "boolean" },
+						level3Sep: { arg: "-level3sep", type: "boolean" },
+						noCenter: { arg: "-nocenter", type: "boolean" },
+						noCrop: { arg: "-nocrop", type: "boolean" },
+						noEmbedCIDFonts: {
+							arg: "-noembcidps",
+							type: "boolean",
+						},
+						noEmbedCIDTrueTypeFonts: {
+							arg: "-noembcidtt",
+							type: "boolean",
+						},
+						noEmbedTrueTypeFonts: {
+							arg: "-noembtt",
+							type: "boolean",
+						},
+						noEmbedType1Fonts: { arg: "-noembt1", type: "boolean" },
+						noShrink: { arg: "-noshrink", type: "boolean" },
+						opi: { arg: "-opi", type: "boolean" },
+						optimizecolorspace: {
+							arg: "-optimizecolorspace",
+							type: "boolean",
+						},
+						originalPageSizes: {
+							arg: "-origpagesizes",
+							type: "boolean",
+						},
+						overprint: { arg: "-overprint", type: "boolean" },
+						ownerPassword: { arg: "-opw", type: "string" },
+						paperHeight: { arg: "-paperh", type: "number" },
+						paperSize: { arg: "-paper", type: "string" },
+						paperWidth: { arg: "-paperw", type: "number" },
+						passfonts: { arg: "-passfonts", type: "boolean" },
+						preload: { arg: "-preload", type: "boolean" },
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						processColorFormat: {
+							arg: "-processcolorformat",
+							type: "string",
+						},
+						processColorProfile: {
+							arg: "-processcolorprofile",
+							type: "string",
+						},
+						quiet: { arg: "-q", type: "boolean" },
+						rasterize: {
+							arg: "-rasterize",
+							type: "string",
+							minVersion: "0.90.0",
+						},
+						resolutionXYAxis: { arg: "-r", type: "number" },
+						userPassword: { arg: "-upw", type: "string" },
+					});
+					break;
+				case "pdfToText":
+					this.#acceptedOptions.set("pdfToText", {
+						boundingBoxXhtml: { arg: "-bbox", type: "boolean" },
+						boundingBoxXhtmlLayout: {
+							arg: "-bbox-layout",
+							type: "boolean",
+						},
+						cropBox: {
+							arg: "-cropbox",
+							type: "boolean",
+							minVersion: "21.03.0",
+						},
+						cropHeight: { arg: "-H", type: "number" },
+						cropWidth: { arg: "-W", type: "number" },
+						cropXAxis: { arg: "-x", type: "number" },
+						cropYAxis: { arg: "-y", type: "number" },
+						eolConvention: { arg: "-eol", type: "string" },
+						firstPageToConvert: { arg: "-f", type: "number" },
+						fixedWidthLayout: { arg: "-fixed", type: "number" },
+						generateHtmlMetaFile: {
+							arg: "-htmlmeta",
+							type: "boolean",
+						},
+						generateTsvFile: { arg: "-tsv", type: "boolean" },
+						lastPageToConvert: { arg: "-l", type: "number" },
+						listEncodingOptions: {
+							arg: "-listenc",
+							type: "boolean",
+						},
+						maintainLayout: { arg: "-layout", type: "boolean" },
+						noDiagonalText: {
+							arg: "-nodiag",
+							type: "boolean",
+							minVersion: "0.80.0",
+						},
+						noPageBreaks: { arg: "-nopgbrk", type: "boolean" },
+						outputEncoding: { arg: "-enc", type: "string" },
+						ownerPassword: { arg: "-opw", type: "string" },
+						printVersionInfo: { arg: "-v", type: "boolean" },
+						quiet: { arg: "-q", type: "boolean" },
+						rawLayout: { arg: "-raw", type: "boolean" },
+						resolution: { arg: "-r", type: "number" },
+						userPassword: { arg: "-upw", type: "string" },
+					});
+					break;
+				case "pdfUnite":
+					this.#acceptedOptions.set("pdfUnite", {
+						printVersionInfo: { arg: "-v", type: "boolean" },
+					});
+					break;
+			}
+		}
+
+		return this.#acceptedOptions.get(functionName);
+	}
+
+	/**
+	 * @author Frazer Smith
 	 * @description Embeds files (attachments) into a PDF file.
 	 * @param {string} file - Filepath of the PDF file to read.
 	 * @param {string} fileToAttach - Filepath of the attachment to be embedded into the PDF file.
@@ -543,7 +638,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfAttach(file, fileToAttach, outputFile, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfAttach;
+		const acceptedOptions = this.#getAcceptedOptions("pdfAttach");
 		const args = parseOptions(acceptedOptions, options);
 		args.push(file, fileToAttach, outputFile);
 
@@ -578,7 +673,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfDetach(file, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfDetach;
+		const acceptedOptions = this.#getAcceptedOptions("pdfDetach");
 		const args = parseOptions(acceptedOptions, options);
 		args.push(file);
 
@@ -601,7 +696,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfFonts(file, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfFonts;
+		const acceptedOptions = this.#getAcceptedOptions("pdfFonts");
 		const versionInfo = await this.#getVersion(this.#pdfFontsBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 
@@ -674,7 +769,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfImages(file, outputPrefix, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfImages;
+		const acceptedOptions = this.#getAcceptedOptions("pdfImages");
 		const versionInfo = await this.#getVersion(this.#pdfImagesBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 
@@ -761,7 +856,7 @@ class Poppler {
 	 * `options.printAsJson` is `true`, or rejects with an `Error` object.
 	 */
 	async pdfInfo(file, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfInfo;
+		const acceptedOptions = this.#getAcceptedOptions("pdfInfo");
 		const versionInfo = await this.#getVersion(this.#pdfInfoBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 
@@ -858,7 +953,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfSeparate(file, outputPattern, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfSeparate;
+		const acceptedOptions = this.#getAcceptedOptions("pdfSeparate");
 		const versionInfo = await this.#getVersion(this.#pdfSeparateBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 		args.push(file, outputPattern);
@@ -975,7 +1070,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfToCairo(file, outputFile, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfToCairo;
+		const acceptedOptions = this.#getAcceptedOptions("pdfToCairo");
 		const versionInfo = await this.#getVersion(this.#pdfToCairoBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 
@@ -1071,7 +1166,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfToHtml(file, outputFile, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfToHtml;
+		const acceptedOptions = this.#getAcceptedOptions("pdfToHtml");
 		const versionInfo = await this.#getVersion(this.#pdfToHtmlBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 
@@ -1186,7 +1281,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfToPpm(file, outputPath, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfToPpm;
+		const acceptedOptions = this.#getAcceptedOptions("pdfToPpm");
 		const versionInfo = await this.#getVersion(this.#pdfToPpmBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 
@@ -1337,7 +1432,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfToPs(file, outputFile, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfToPs;
+		const acceptedOptions = this.#getAcceptedOptions("pdfToPs");
 		const versionInfo = await this.#getVersion(this.#pdfToPsBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 
@@ -1434,7 +1529,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfToText(file, outputFile, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfToText;
+		const acceptedOptions = this.#getAcceptedOptions("pdfToText");
 		const versionInfo = await this.#getVersion(this.#pdfToTextBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 
@@ -1494,7 +1589,7 @@ class Poppler {
 	 * @returns {Promise<string>} A promise that resolves with a stdout string, or rejects with an `Error` object.
 	 */
 	async pdfUnite(files, outputFile, options = {}) {
-		const acceptedOptions = Poppler.#acceptedOptions.pdfUnite;
+		const acceptedOptions = this.#getAcceptedOptions("pdfUnite");
 		const versionInfo = await this.#getVersion(this.#pdfUniteBin);
 		const args = parseOptions(acceptedOptions, options, versionInfo);
 		args.push(...files, outputFile);


### PR DESCRIPTION
Building the object on init is slow, especially if not all functions are used. So only build and cache it as and when a function is used.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
