### PR TITLE
fix(index): ignore warnings if exit code is valid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1303,10 +1303,10 @@ class Poppler {
 
 			child.on("close", (code) => {
 				/* istanbul ignore else */
-				if (stdErr !== "") {
-					reject(new Error(stdErr.trim()));
-				} else if (code === 0) {
+				if (code === 0) {
 					resolve(ERROR_MSGS[code]);
+				} else if (stdErr !== "") {
+					reject(new Error(stdErr.trim()));
 				} else {
 					reject(
 						new Error(


### PR DESCRIPTION
Hi

Fixes an issue an issue where warnings from invalid pdf documents lead to an exception. Poppler emits warnings on stdout, therefore the exit code should be used as first priority to evaluate the execution.

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
