### PR TITLE
refactor(index): enable regex charset and unicode with `v` flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,9 @@ const ERROR_MSGS = {
 };
 
 // Cache immutable regex as they are expensive to create and garbage collect
-const POPPLER_VERSION_REG = /(\d{1,2}\.\d{1,2}\.\d{1,2})/u;
-const PDF_INFO_FILE_SIZES_REG = /(File\s+size:\s+)0(\s+)bytes/u;
-const PDF_INFO_PATH_REG = /(.+)pdfinfo/u;
+const POPPLER_VERSION_REG = /(\d{1,2}\.\d{1,2}\.\d{1,2})/v;
+const PDF_INFO_FILE_SIZES_REG = /(File\s+size:\s+)0(\s+)bytes/v;
+const PDF_INFO_PATH_REG = /(.+)pdfinfo/v;
 
 /**
  * @typedef {object} OptionDetails

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -25,9 +25,9 @@ const execFileAsync = promisify(execFile);
 const { Poppler } = require("./index");
 
 // Cache immutable regex as they are expensive to create and garbage collect
-const CMD_FAILED_REG = /^Command failed:/u;
-const SYNTAX_WARNING_REG = /^Syntax Warning:/u;
-const IO_ERROR_REG = /^I\/O Error:/u;
+const CMD_FAILED_REG = /^Command failed:/v;
+const SYNTAX_WARNING_REG = /^Syntax Warning:/v;
+const IO_ERROR_REG = /^I\/O Error:/v;
 
 const testDirectory =
 	join(__dirname, "..", "test_resources", "test_files") + sep;
@@ -43,7 +43,7 @@ function getTestBinaryPath() {
 	const which = spawnSync(platform === "win32" ? "where" : "which", [
 		"pdfinfo",
 	]).stdout.toString();
-	let popplerPath = /(.+)pdfinfo/u.exec(which)?.[1];
+	let popplerPath = /(.+)pdfinfo/v.exec(which)?.[1];
 
 	if (platform === "win32" && !popplerPath) {
 		popplerPath = join(
@@ -311,7 +311,7 @@ describe("Node-Poppler module", () => {
 			expect.assertions(1);
 			await poppler.pdfImages(undefined, "file_prefix").catch((err) => {
 				expect(err.message).toMatch(
-					/^I\/O Error: Couldn't open file 'undefined'/u
+					/^I\/O Error: Couldn't open file 'undefined'/v
 				);
 			});
 		});
@@ -947,7 +947,7 @@ describe("Node-Poppler module", () => {
 				["-v"]
 			);
 
-			version = /(\d{1,2}\.\d{1,2}\.\d{1,2})/u.exec(stderr)[1];
+			version = /(\d{1,2}\.\d{1,2}\.\d{1,2})/v.exec(stderr)[1];
 		});
 
 		it("Accepts options and only process 1 page of PDF file", async () => {
@@ -1146,8 +1146,8 @@ describe("Node-Poppler module", () => {
 				options
 			);
 
-			expect(res).toMatch(/^\s*/u);
-			expect(res).toMatch(/\s*$/u);
+			expect(res).toMatch(/^\s*/v);
+			expect(res).toMatch(/\s*$/v);
 		});
 
 		it("Accepts options and only process 2 pages of PDF file", async () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [ ] Run `npm test`
- [ ] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [ ] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
