### PR TITLE
ci(ci): ignore dependabot prs in coverage updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,11 @@ jobs:
               run: npm run test:unit:coverage
 
             - name: Coveralls parallel
-              if: github.event.pull_request.head.repo.full_name == github.repository
+              if: >
+                  github.event_name == 'push' ||
+                  (github.event_name == 'pull_request' &&
+                   github.event.pull_request.head.repo.full_name == github.repository &&
+                   github.event.pull_request.user.login != 'dependabot[bot]')
               uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -152,7 +156,11 @@ jobs:
     coverage:
         name: Aggregate Coverage Calculations
         needs: unit-tests
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: >
+            github.event_name == 'push' ||
+            (github.event_name == 'pull_request' &&
+             github.event.pull_request.head.repo.full_name == github.repository &&
+             github.event.pull_request.user.login != 'dependabot[bot]')
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
               run: npm run test:unit:coverage
 
             - name: Coveralls parallel
-              if: github.repository == 'Fdawgs/node-poppler'
+              if: github.event.pull_request.head.repo.full_name == github.repository
               uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -152,7 +152,7 @@ jobs:
     coverage:
         name: Aggregate Coverage Calculations
         needs: unit-tests
-        if: github.repository == 'Fdawgs/node-poppler'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
         permissions:
             contents: read


### PR DESCRIPTION
This is a batch PR created by a script. Please review prior to merging.