### PR TITLE
perf(index): cache typeof result in `parseOptions`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -604,8 +604,9 @@ function parseOptions(acceptedOptions, options, version) {
 		// @ts-ignore: Keys are from options, TS cannot infer this
 		const option = options[key];
 		const acceptedOption = acceptedOptions[key];
+		const optionType = typeof option;
 
-		if (acceptedOption.type === typeof option) {
+		if (acceptedOption.type === optionType) {
 			// Skip boolean options if false
 			if (acceptedOption.type !== "boolean" || option) {
 				// Arg will be empty for some non-standard options
@@ -613,7 +614,7 @@ function parseOptions(acceptedOptions, options, version) {
 					args.push(acceptedOption.arg);
 				}
 
-				if (typeof option !== "boolean") {
+				if (optionType !== "boolean") {
 					args.push(option);
 				}
 			}
@@ -621,7 +622,7 @@ function parseOptions(acceptedOptions, options, version) {
 			invalidArgs.push(
 				`Invalid value type provided for option '${key}', expected ${
 					acceptedOption.type
-				} but received ${typeof option}`
+				} but received ${optionType}`
 			);
 		}
 


### PR DESCRIPTION
`typeof` is cheap but not free, it still requires the V8 engine to evaluate the operand and return a string. Caching the result in a local variable avoids redundant eval on the error path.

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
