### PR TITLE
chore(index): replace `any` type with union of poppler func typedefs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -580,7 +580,8 @@ function execBinary(binary, args, file, options = {}) {
  * version of binary.
  * @ignore
  * @param {PopplerAcceptedOptions} acceptedOptions - Object containing accepted options.
- * @param {Record<string, any>} options - Object containing options to pass to binary.
+ * @param {(PdfAttachOptions|PdfDetachOptions|PdfFontsOptions|PdfImagesOptions|PdfInfoOptions|PdfSeparateOptions|PdfToCairoOptions|PdfToHtmlOptions|PdfToPpmOptions|PdfToPsOptions|PdfToTextOptions|PdfUniteOptions)} options
+ * - Object containing options to pass to binary.
  * @param {string} [version] - Version of binary.
  * @returns {string[]} Array of CLI arguments.
  * @throws {Error} If invalid arguments provided.

--- a/src/index.js
+++ b/src/index.js
@@ -489,6 +489,8 @@ const PDF_INFO_PATH_REG = /(.+)pdfinfo/u;
  * @property {boolean} [printVersionInfo] Print copyright and version information.
  */
 
+/** @typedef {(PdfAttachOptions|PdfDetachOptions|PdfFontsOptions|PdfImagesOptions|PdfInfoOptions|PdfSeparateOptions|PdfToCairoOptions|PdfToHtmlOptions|PdfToPpmOptions|PdfToPsOptions|PdfToTextOptions|PdfUniteOptions)} PopplerOptions */
+
 /**
  * @typedef {object} PopplerExtraOptions
  * @property {AbortSignal} [signal] An `AbortSignal` that can be used to cancel the operation.
@@ -580,8 +582,7 @@ function execBinary(binary, args, file, options = {}) {
  * version of binary.
  * @ignore
  * @param {PopplerAcceptedOptions} acceptedOptions - Object containing accepted options.
- * @param {(PdfAttachOptions|PdfDetachOptions|PdfFontsOptions|PdfImagesOptions|PdfInfoOptions|PdfSeparateOptions|PdfToCairoOptions|PdfToHtmlOptions|PdfToPpmOptions|PdfToPsOptions|PdfToTextOptions|PdfUniteOptions)} options
- * - Object containing options to pass to binary.
+ * @param {PopplerOptions} options - Object containing options to pass to binary.
  * @param {string} [version] - Version of binary.
  * @returns {string[]} Array of CLI arguments.
  * @throws {Error} If invalid arguments provided.


### PR DESCRIPTION
Improves type safety and enables better IntelliSense/autocomplete in VS Code et al.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
