### PR TITLE
fix(index): add `minVersion` to `pdfAttach` options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -761,8 +761,16 @@ class Poppler {
 					this.#acceptedOptions.set(
 						"pdfAttach",
 						freeze({
-							printVersionInfo: { arg: "-v", type: "boolean" },
-							replace: { arg: "-replace", type: "boolean" },
+							printVersionInfo: {
+								arg: "-v",
+								type: "boolean",
+								minVersion: "0.75.0",
+							},
+							replace: {
+								arg: "-replace",
+								type: "boolean",
+								minVersion: "0.75.0",
+							},
 						})
 					);
 					break;
@@ -1244,7 +1252,8 @@ class Poppler {
 	async pdfAttach(file, fileToAttach, outputFile, options = {}, extras = {}) {
 		const { signal } = extras;
 		const acceptedOptions = this.#getAcceptedOptions("pdfAttach");
-		const args = parseOptions(acceptedOptions, options);
+		const versionInfo = await this.#getVersion(this.#pdfAttachBin);
+		const args = parseOptions(acceptedOptions, options, versionInfo);
 		args.push(file, fileToAttach, outputFile);
 
 		return execBinary(this.#pdfAttachBin, args, undefined, { signal });


### PR DESCRIPTION
pdfattach binary was introduced with Poppler 0.75.0. See https://gitlab.freedesktop.org/poppler/poppler/-/blob/master/NEWS#L1475

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
