### PR TITLE
fix(index): skip version checks for `false` boolean options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -609,16 +609,18 @@ function parseOptions(acceptedOptions, options, version) {
 		const optionType = typeof option;
 
 		if (acceptedOption.type === optionType) {
-			// Skip boolean options if false
-			if (acceptedOption.type !== "boolean" || option) {
-				// Arg will be empty for some non-standard options
-				if (acceptedOption.arg !== "") {
-					args.push(acceptedOption.arg);
-				}
+			// Boolean options set to false won't be passed to the binary; skip arg and version checks
+			if (acceptedOption.type === "boolean" && !option) {
+				continue;
+			}
 
-				if (optionType !== "boolean") {
-					args.push(option);
-				}
+			// Arg will be empty for some non-standard options
+			if (acceptedOption.arg !== "") {
+				args.push(acceptedOption.arg);
+			}
+
+			if (optionType !== "boolean") {
+				args.push(option);
 			}
 		} else {
 			invalidArgs.push(

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1237,6 +1237,25 @@ describe("Node-Poppler module", () => {
 			}
 		});
 
+		it("Does not reject with an Error object if option provided is only available in a later version of the pdftoppm binary than what was provided, but is set to false", async () => {
+			const options = {
+				printProgress: false,
+			};
+
+			if (lt(version, "21.03.0", { loose: true })) {
+				const res = await poppler.pdfToPpm(
+					file,
+					`${testDirectory}pdf_1.3_NHS_Constitution`,
+					options
+				);
+
+				expect(res).toBe("No Error");
+				await expect(
+					access(`${testDirectory}pdf_1.3_NHS_Constitution-01.ppm`)
+				).resolves.toBeUndefined();
+			}
+		});
+
 		it("Rejects with an Error object if invalid option is passed to function", async () => {
 			const options = {
 				middlePageToConvert: "test",


### PR DESCRIPTION
Boolean options set to `false` are never passed to the underlying binary, so it is redundant doing version checking on them and throwing errors.

Probably a tiny performance boost in here as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
