### PR TITLE
fix(index): skip undefined options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -609,6 +609,10 @@ function parseOptions(acceptedOptions, options, version) {
 		const acceptedOption = acceptedOptions[key];
 		const optionType = typeof option;
 
+		if (optionType === "undefined") {
+			continue;
+		}
+
 		if (acceptedOption.type === optionType) {
 			// Boolean options set to false won't be passed to the binary; skip arg and version checks
 			if (acceptedOption.type === "boolean" && !option) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -849,6 +849,19 @@ describe("Node-Poppler module", () => {
 					access(`${outputFile}-01.png`)
 				).resolves.toBeUndefined();
 			});
+
+			it("Supports options being undefined", async () => {
+				const options = {
+					pngFile: true,
+					scalePageTo: undefined,
+				};
+				const outputFile = `${testDirectory}pdf_1.3_NHS_Constitution`;
+				const res = await poppler.pdfToCairo(file, outputFile, options);
+				expect(res).toBe("No Error");
+				await expect(
+					access(`${outputFile}-01.png`)
+				).resolves.toBeUndefined();
+			});
 		});
 
 		describe("PDF-to-PS option", () => {


### PR DESCRIPTION
According to typings most (if not all?) options can be `undefined`. 

However, making an option `undefined` causes errors like
 
```
Error: Invalid value type provided for option 'scalePageTo', expected number but received undefined
```

This PR fixes it by continuing in `parseOptions()` if `optionType` is `undefined`, skipping over the option.

(I probably didn't put the test in the correct suite, but I was working with PDF to PNG when I discovered this so I knew I could easily test for it there)

#### Checklist

- [ ✅] Run `npm test`
- [ ✅] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
