### PR TITLE
fix(options/pdftops)!: use camelcase for `optimizecolorspace`

### DIFF
--- a/src/options/pdftops.js
+++ b/src/options/pdftops.js
@@ -185,7 +185,7 @@ module.exports = {
 	rasterize: {
 		arg: "-rasterize",
 		type: "string",
-		minVersion: "0.90.0",
+		minVersion: "0.32.0",
 	},
 	resolutionXYAxis: { arg: "-r", type: "number" },
 	userPassword: { arg: "-upw", type: "string" },

--- a/src/options/pdftops.js
+++ b/src/options/pdftops.js
@@ -64,7 +64,7 @@
  * @property {boolean} [noShrink] Do not scale PDF pages which are larger than the paper.
  * By default, pages larger than the paper are shrunk to fit.
  * @property {boolean} [opi] Generate OPI comments for all images and forms which have OPI information.
- * @property {boolean} [optimizecolorspace] By default, bitmap images in the PDF pass through to the
+ * @property {boolean} [optimizeColorSpace] By default, bitmap images in the PDF pass through to the
  * output PostScript in their original color space, which produces predictable results.
  * This option converts RGB and CMYK images into Gray images if every pixel of the image has equal components.
  * This can fix problems when doing color separations of PDFs that contain embedded black and
@@ -156,7 +156,7 @@ module.exports = {
 	},
 	noShrink: { arg: "-noshrink", type: "boolean" },
 	opi: { arg: "-opi", type: "boolean" },
-	optimizecolorspace: {
+	optimizeColorSpace: {
 		arg: "-optimizecolorspace",
 		type: "boolean",
 	},

--- a/src/options/pdftops.js
+++ b/src/options/pdftops.js
@@ -159,6 +159,7 @@ module.exports = {
 	optimizeColorSpace: {
 		arg: "-optimizecolorspace",
 		type: "boolean",
+		minVersion: "0.32.0",
 	},
 	originalPageSizes: {
 		arg: "-origpagesizes",


### PR DESCRIPTION
BREAKING CHANGE: `optimizecolorspace` renamed to `optimizeColorSpace` for pdfToPs function; large number of fixes to minimum version for options across all functions

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
