### PR TITLE
fix(options/pdffonts): add `minVersion` properties

### DIFF
--- a/src/options/pdffonts.js
+++ b/src/options/pdffonts.js
@@ -13,10 +13,10 @@
 
 /** @type {Record<keyof PdfFontsOptions, import("../index").OptionDetails>} */
 module.exports = {
-	firstPageToExamine: { arg: "-f", type: "number" },
-	lastPageToExamine: { arg: "-l", type: "number" },
-	listSubstitutes: { arg: "-subst", type: "boolean" },
-	ownerPassword: { arg: "-opw", type: "string" },
-	printVersionInfo: { arg: "-v", type: "boolean" },
-	userPassword: { arg: "-upw", type: "string" },
+	firstPageToExamine: { arg: "-f", type: "number", minVersion: "0.1.0" },
+	lastPageToExamine: { arg: "-l", type: "number", minVersion: "0.1.0" },
+	listSubstitutes: { arg: "-subst", type: "boolean", minVersion: "0.19.0" },
+	ownerPassword: { arg: "-opw", type: "string", minVersion: "0.1.0" },
+	printVersionInfo: { arg: "-v", type: "boolean", minVersion: "0.1.0" },
+	userPassword: { arg: "-upw", type: "string", minVersion: "0.1.0" },
 };


### PR DESCRIPTION
Sourced from https://poppler.freedesktop.org/releases.html

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
