### PR TITLE
fix(options/pdfseparate): add `minVersion` properties

### DIFF
--- a/src/options/pdfseparate.js
+++ b/src/options/pdfseparate.js
@@ -11,7 +11,7 @@
 
 /** @type {Record<keyof PdfSeparateOptions, import("../index").OptionDetails>} */
 module.exports = {
-	firstPageToExtract: { arg: "-f", type: "number" },
-	lastPageToExtract: { arg: "-l", type: "number" },
-	printVersionInfo: { arg: "-v", type: "boolean" },
+	firstPageToExtract: { arg: "-f", type: "number", minVersion: "0.18.0" },
+	lastPageToExtract: { arg: "-l", type: "number", minVersion: "0.18.0" },
+	printVersionInfo: { arg: "-v", type: "boolean", minVersion: "0.18.0" },
 };


### PR DESCRIPTION
`pdfseparate` was introduced in v0.18.0, renamed from pdfextract.
See https://gitlab.freedesktop.org/poppler/poppler/-/raw/master/NEWS

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
