### PR TITLE
feat(pdftoppm): add `jpegOptions` and `scaleDimensionBeforeRotation` opt

### DIFF
--- a/src/options/pdftoppm.js
+++ b/src/options/pdftoppm.js
@@ -58,7 +58,7 @@
  * @property {number} [resolutionYAxis] Specifies the Y resolution, in pixels per inch of
  * image files (or rasterized regions in vector output). The default is 150 PPI.
  * @property {boolean} [scaleDimensionBeforeRotation] Swaps horizontal and vertical size for
- * a rotated (landscape) pdf before scaling instead of after.
+ * a rotated (landscape) PDF before scaling instead of after.
  * @property {number} [scalePageTo] Scales the long side of each page (width for landscape
  * pages, height for portrait pages) to fit in scale-to pixels. The size of the short side will
  * be determined by the aspect ratio of the page.

--- a/src/options/pdftoppm.js
+++ b/src/options/pdftoppm.js
@@ -34,6 +34,12 @@
  * @property {boolean} [grayscaleFile] Generate grayscale PGM file (instead of a color PPM file).
  * @property {boolean} [hideAnnotations] Hide annotations.
  * @property {boolean} [jpegFile] Generate JPEG file instead of a PPM file.
+ * @property {string} [jpegOptions] When used with `options.jpegFile`, this option can
+ * be used to control the JPEG compression parameters. It takes a string of the form
+ * `"<opt>=<val>[,<opt>=<val>]"`. Currently available options are:
+ * - `quality` Selects the JPEG quality value. The value must be an integer between 0 and 100.
+ * - `progressive` Select progressive JPEG output. The possible values are "y", "n", indicating
+ * progressive (yes) or non-progressive (no), respectively.
  * @property {number} [lastPageToConvert] Specifies the last page to convert.
  * @property {boolean} [monochromeFile] Generate monochrome PBM file (instead of a color PPM file).
  * @property {boolean} [oddPagesOnly] Generates only the odd numbered pages.
@@ -51,6 +57,8 @@
  * inch of image files (or rasterized regions in vector output). The default is 150 PPI.
  * @property {number} [resolutionYAxis] Specifies the Y resolution, in pixels per inch of
  * image files (or rasterized regions in vector output). The default is 150 PPI.
+ * @property {boolean} [scaleDimensionBeforeRotation] Swaps horizontal and vertical size for
+ * a rotated (landscape) pdf before scaling instead of after.
  * @property {number} [scalePageTo] Scales the long side of each page (width for landscape
  * pages, height for portrait pages) to fit in scale-to pixels. The size of the short side will
  * be determined by the aspect ratio of the page.
@@ -70,17 +78,14 @@
 
 /** @type {Record<keyof PdfToPpmOptions, import("../index").OptionDetails>} */
 module.exports = {
-	antialiasFonts: { arg: "-aa", type: "string" },
-	antialiasVectors: {
-		arg: "-aaVector",
-		type: "string",
-	},
-	cropBox: { arg: "-cropbox", type: "boolean" },
-	cropHeight: { arg: "-H", type: "number" },
-	cropSize: { arg: "-sz", type: "number" },
-	cropWidth: { arg: "-W", type: "number" },
-	cropXAxis: { arg: "-x", type: "number" },
-	cropYAxis: { arg: "-y", type: "number" },
+	antialiasFonts: { arg: "-aa", type: "string", minVersion: "0.1.0" },
+	antialiasVectors: { arg: "-aaVector", type: "string", minVersion: "0.1.0" },
+	cropBox: { arg: "-cropbox", type: "boolean", minVersion: "0.11.0" },
+	cropHeight: { arg: "-H", type: "number", minVersion: "0.1.0" },
+	cropSize: { arg: "-sz", type: "number", minVersion: "0.1.0" },
+	cropWidth: { arg: "-W", type: "number", minVersion: "0.1.0" },
+	cropXAxis: { arg: "-x", type: "number", minVersion: "0.1.0" },
+	cropYAxis: { arg: "-y", type: "number", minVersion: "0.1.0" },
 	defaultCmykProfile: {
 		arg: "-defaultcmykprofile",
 		type: "string",
@@ -101,59 +106,61 @@ module.exports = {
 		type: "string",
 		minVersion: "0.90.0",
 	},
-	evenPagesOnly: { arg: "-e", type: "boolean" },
-	firstPageToConvert: { arg: "-f", type: "number" },
+	evenPagesOnly: { arg: "-e", type: "boolean", minVersion: "0.13.3" },
+	firstPageToConvert: { arg: "-f", type: "number", minVersion: "0.1.0" },
 	forcePageNumber: {
 		arg: "-forcenum",
 		type: "boolean",
 		minVersion: "0.75.0",
 	},
-	freetype: { arg: "-freetype", type: "string" },
-	grayscaleFile: { arg: "-gray", type: "boolean" },
+	freetype: { arg: "-freetype", type: "string", minVersion: "0.1.0" },
+	grayscaleFile: { arg: "-gray", type: "boolean", minVersion: "0.1.0" },
 	hideAnnotations: {
 		arg: "-hide-annotations",
 		type: "boolean",
 		minVersion: "0.84.0",
 	},
-	jpegFile: { arg: "-jpeg", type: "boolean" },
-	lastPageToConvert: { arg: "-l", type: "number" },
-	monochromeFile: { arg: "-mono", type: "boolean" },
-	oddPagesOnly: { arg: "-o", type: "boolean" },
-	ownerPassword: { arg: "-opw", type: "string" },
-	pngFile: { arg: "-png", type: "boolean" },
-	printProgress: {
-		arg: "-progress",
+	jpegFile: { arg: "-jpeg", type: "boolean", minVersion: "0.13.0" },
+	jpegOptions: { arg: "-jpegopt", type: "string", minVersion: "0.58.0" },
+	lastPageToConvert: { arg: "-l", type: "number", minVersion: "0.1.0" },
+	monochromeFile: { arg: "-mono", type: "boolean", minVersion: "0.1.0" },
+	oddPagesOnly: { arg: "-o", type: "boolean", minVersion: "0.13.3" },
+	ownerPassword: { arg: "-opw", type: "string", minVersion: "0.1.0" },
+	pngFile: { arg: "-png", type: "boolean", minVersion: "0.11.3" },
+	printProgress: { arg: "-progress", type: "boolean", minVersion: "21.03.0" },
+	printVersionInfo: { arg: "-v", type: "boolean", minVersion: "0.1.0" },
+	quiet: { arg: "-q", type: "boolean", minVersion: "0.1.0" },
+	resolutionXAxis: { arg: "-rx", type: "number", minVersion: "0.1.0" },
+	resolutionXYAxis: { arg: "-r", type: "number", minVersion: "0.1.0" },
+	resolutionYAxis: { arg: "-ry", type: "number", minVersion: "0.1.0" },
+	scaleDimensionBeforeRotation: {
+		arg: "-scale-dimension-before-rotation",
 		type: "boolean",
-		minVersion: "21.03.0",
+		minVersion: "0.84.0",
 	},
-	printVersionInfo: { arg: "-v", type: "boolean" },
-	quiet: { arg: "-q", type: "boolean" },
-	resolutionXAxis: { arg: "-rx", type: "number" },
-	resolutionXYAxis: { arg: "-r", type: "number" },
-	resolutionYAxis: { arg: "-ry", type: "number" },
-	scalePageTo: { arg: "-scale-to", type: "number" },
+	scalePageTo: { arg: "-scale-to", type: "number", minVersion: "0.1.0" },
 	scalePageToXAxis: {
 		arg: "-scale-to-x",
 		type: "number",
+		minVersion: "0.1.0",
 	},
 	scalePageToYAxis: {
 		arg: "-scale-to-y",
 		type: "number",
+		minVersion: "0.1.0",
 	},
-	separator: {
-		arg: "-sep",
-		type: "string",
-		minVersion: "0.75.0",
-	},
-	singleFile: { arg: "-singlefile", type: "boolean" },
+	separator: { arg: "-sep", type: "string", minVersion: "0.75.0" },
+	singleFile: { arg: "-singlefile", type: "boolean", minVersion: "0.17.0" },
 	thinLineMode: {
 		arg: "-thinlinemode",
 		type: "string",
+		minVersion: "0.25.0",
 	},
 	tiffCompression: {
 		arg: "-tiffcompression",
 		type: "string",
+		minVersion: "0.17.0",
 	},
-	tiffFile: { arg: "-tiff", type: "boolean" },
-	userPassword: { arg: "-upw", type: "string" },
+	tiffFile: { arg: "-tiff", type: "boolean", minVersion: "0.17.0" },
+	userPassword: { arg: "-upw", type: "string", minVersion: "0.1.0" },
 };


### PR DESCRIPTION
See https://manpages.debian.org/experimental/poppler-utils/pdftoppm.1.en.html#jpegopt and https://gitlab.freedesktop.org/poppler/poppler/-/raw/master/NEWS

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
