### PR TITLE
fix(pdftops)!: use camelcase for `passfonts`

### DIFF
--- a/src/options/pdftops.js
+++ b/src/options/pdftops.js
@@ -80,7 +80,7 @@
  * of each page to match the size specified in the PDF file. If none of the paperSize,
  * paperWidth, or paperHeight options are specified the default is to match the paper size.
  * @property {number} [paperWidth] Set the paper width, in points.
- * @property {boolean} [passfonts] By default, references to non-embedded 8-bit fonts
+ * @property {boolean} [passFonts] By default, references to non-embedded 8-bit fonts
  * in the PDF file are substituted with the closest `Helvetica`, `Times-Roman`, or `Courier` font.
  * This option passes references to non-embedded fonts through to the PostScript file.
  * @property {boolean} [preload] Preload images and forms.
@@ -170,7 +170,7 @@ module.exports = {
 	paperHeight: { arg: "-paperh", type: "number" },
 	paperSize: { arg: "-paper", type: "string" },
 	paperWidth: { arg: "-paperw", type: "number" },
-	passfonts: { arg: "-passfonts", type: "boolean" },
+	passFonts: { arg: "-passfonts", type: "boolean" },
 	preload: { arg: "-preload", type: "boolean" },
 	printVersionInfo: { arg: "-v", type: "boolean" },
 	processColorFormat: {


### PR DESCRIPTION
BREAKING CHANGE: `passfonts` renamed to `passFonts` for pdfToPs function

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
