### PR TITLE
style(options): fix jsdoc backtick usage

### DIFF
--- a/src/options/pdfimages.js
+++ b/src/options/pdfimages.js
@@ -12,7 +12,7 @@
  * @property {boolean} [jpegFile] Generate JPEG images as JPEG files.
  * @property {boolean} [list] Instead of writing the images, list the
  * images along with various information for each image.
- * NOTE: Do not specify the outputPrefix with this option.
+ * NOTE: Do not specify the `outputPrefix` with this option.
  * @property {boolean} [outputPageNumbers] Include page numbers in output file names.
  * @property {string} [ownerPassword] Owner password (for encrypted files).
  * @property {boolean} [pngFile] Change the default output format to PNG.

--- a/src/options/pdfinfo.js
+++ b/src/options/pdfinfo.js
@@ -6,7 +6,7 @@
  * @property {number} [lastPageToConvert] Last page to print.
  * @property {boolean} [listEncodingOptions] List the available encodings.
  * @property {string} [outputEncoding] Sets the encoding to use for text output.
- * This defaults to `UTF-8`.
+ * This defaults to `'UTF-8'`.
  * @property {string} [ownerPassword] Owner password (for encrypted files).
  * @property {boolean} [printAsJson] Print result as a JSON object.
  * @property {boolean} [printBoundingBoxes] Prints the page box bounding boxes:

--- a/src/options/pdftocairo.js
+++ b/src/options/pdftocairo.js
@@ -82,10 +82,10 @@
  * pages, height for portrait pages) to fit in scale-to pixels. The size of the short side will
  * be determined by the aspect ratio of the page (PNG/JPEG/TIFF only).
  * @property {number} [scalePageToXAxis] Scales each page horizontally to fit in scale-to-x
- * pixels. If scale-to-y is set to `-1`, the vertical size will determined by the aspect ratio of
+ * pixels. If scale-to-y is set to `-1`, the vertical size will be determined by the aspect ratio of
  * the page (PNG/JPEG/TIFF only).
  * @property {number} [scalePageToYAxis] Scales each page vertically to fit in scale-to-y
- * pixels. If scale-to-x is set to `-1`, the horizontal size will determined by the aspect ratio of
+ * pixels. If scale-to-x is set to `-1`, the horizontal size will be determined by the aspect ratio of
  * the page (PNG/JPEG/TIFF only).
  * @property {boolean} [singleFile] Writes only the first page and does not add digits.
  * Can only be used with `options.jpegFile`, `options.pngFile`, and `options.tiffFile`.

--- a/src/options/pdftocairo.js
+++ b/src/options/pdftocairo.js
@@ -34,34 +34,34 @@
  * @property {string} [jpegOptions] When used with `options.jpegFile`, this option can
  * be used to control the JPEG compression parameters. It takes a string of the form
  * `"<opt>=<val>[,<opt>=<val>]"`. Currently available options are:
- * - `quality` Selects the JPEG quality value. The value must be an integer between 0 and 100.
- * - `progressive` Select progressive JPEG output. The possible values are "y", "n", indicating
- * progressive (yes) or non-progressive (no), respectively.
+ * - `quality` Selects the JPEG quality value. The value must be an integer between 0 and 100
+ * - `progressive` Select progressive JPEG output. The possible values are `"y"`, `"n"`, indicating
+ * progressive (yes) or non-progressive (no), respectively
  * - `optimize` Sets whether to compute optimal Huffman coding tables for the JPEG output, which
- * will create smaller files but make an extra pass over the data. The value must be "y" or "n",
- * with "y" performing optimization, otherwise the default Huffman tables are used.
+ * will create smaller files but make an extra pass over the data. The value must be `"y"` or `"n"`,
+ * with `"y"` performing optimization, otherwise the default Huffman tables are used
  *
  * Example: `"quality=95,optimize=y"`.
  * @property {number} [lastPageToConvert] Specifies the last page to convert.
  * @property {boolean} [monochromeFile] Generate monochrome file (PNG and TIFF only).
  * @property {boolean} [noCenter] By default, PDF pages smaller than the paper
  * (after any scaling) are centered on the paper. This option causes them to be aligned to
- * the lower-left corner of the paper instead (PS,PDF,SVG only).
+ * the lower-left corner of the paper instead (PS, PDF, and SVG only).
  * @property {boolean} [noCrop] By default, printing output is cropped to the CropBox
- * specified in the PDF file. This option disables cropping (PS, PDF, SVG only).
+ * specified in the PDF file. This option disables cropping (PS, PDF, and SVG only).
  * @property {boolean} [noShrink] Do not scale PDF pages which are larger than the paper
- * (PS,PDF,SVG only). By default, pages larger than the paper are shrunk to fit.
+ * (PS, PDF, SVG only). By default, pages larger than the paper are shrunk to fit.
  * @property {boolean} [oddPagesOnly] Generates only the odd numbered pages.
  * @property {boolean} [originalPageSizes] Set the paper size of each page to match
  * the size specified in the PDF file.
  * @property {string} [ownerPassword] Specify the owner password for the PDF file.
  * Providing this will bypass all security restrictions.
- * @property {number} [paperHeight] Set the paper height, in points (PS, PDF, SVG only).
- * @property {('A3'|'A4'|'legal'|'letter'|'match')} [paperSize] Set the paper size to one of `A3`, `A4`,
- * `legal`, or `letter` (PS,PDF,SVG only). This can also be set to `match`, which will set the paper size
- * of each page to match the size specified in the PDF file. If none of the paperSize,
- * paperWidth, or paperHeight options are specified the default is to match the paper size.
- * @property {number} [paperWidth] Set the paper width, in points (PS,PDF,SVG only).
+ * @property {number} [paperHeight] Set the paper height, in points (PS, PDF, and SVG only).
+ * @property {('A3'|'A4'|'legal'|'letter'|'match')} [paperSize] Set the paper size to one of `'A3'`, `'A4'`,
+ * `'legal'`, or `'letter'` (PS, PDF, and SVG only). This can also be set to `'match'`, which will set the
+ * paper size of each page to match the size specified in the PDF file. If none of `options.paperSize`,
+ * `options.paperWidth`, or `options.paperHeight` is specified the default is to match the paper size.
+ * @property {number} [paperWidth] Set the paper width, in points (PS, PDF, and SVG only).
  * @property {boolean} [pdfFile] Generate PDF file.
  * @property {boolean} [pngFile] Generate PNG file(s).
  * @property {boolean} [printVersionInfo] Print copyright and version information.
@@ -73,19 +73,19 @@
  * Level 2 features plus shading patterns and masked images. This is the default setting.
  * @property {boolean} [quiet] Do not print any messages or errors.
  * @property {number} [resolutionXAxis] Specifies the X resolution, in pixels per inch of
- * image files (or rasterized regions in vector output). The default is 150 PPI.
+ * image files (or rasterized regions in vector output). The default is `150` PPI.
  * @property {number} [resolutionXYAxis] Specifies the X and Y resolution, in pixels per
- * inch of image files (or rasterized regions in vector output). The default is 150 PPI.
+ * inch of image files (or rasterized regions in vector output). The default is `150` PPI.
  * @property {number} [resolutionYAxis] Specifies the Y resolution, in pixels per inch of
- * image files (or rasterized regions in vector output). The default is 150 PPI.
+ * image files (or rasterized regions in vector output). The default is `150` PPI.
  * @property {number} [scalePageTo] Scales the long side of each page (width for landscape
  * pages, height for portrait pages) to fit in scale-to pixels. The size of the short side will
  * be determined by the aspect ratio of the page (PNG/JPEG/TIFF only).
  * @property {number} [scalePageToXAxis] Scales each page horizontally to fit in scale-to-x
- * pixels. If scale-to-y is set to -1, the vertical size will determined by the aspect ratio of
+ * pixels. If scale-to-y is set to `-1`, the vertical size will determined by the aspect ratio of
  * the page (PNG/JPEG/TIFF only).
  * @property {number} [scalePageToYAxis] Scales each page vertically to fit in scale-to-y
- * pixels. If scale-to-x is set to -1, the horizontal size will determined by the aspect ratio of
+ * pixels. If scale-to-x is set to `-1`, the horizontal size will determined by the aspect ratio of
  * the page (PNG/JPEG/TIFF only).
  * @property {boolean} [singleFile] Writes only the first page and does not add digits.
  * Can only be used with `options.jpegFile`, `options.pngFile`, and `options.tiffFile`.

--- a/src/options/pdftohtml.js
+++ b/src/options/pdftohtml.js
@@ -10,7 +10,7 @@
  * @property {boolean} [fontFullName] Outputs the font name without any substitutions.
  * @property {boolean} [ignoreImages] Ignore images.
  * @property {('JPG'|'PNG')} [imageFormat] Image file format for Splash output (JPG or PNG).
- * If complexOutput is selected, but imageFormat is not specified, PNG will be assumed.
+ * If `options.complexOutput` is enabled, but `options.imageFormat` is not specified, PNG will be assumed.
  * @property {number} [lastPageToConvert] Last page to print.
  * @property {boolean} [noDrm] Override document DRM settings.
  * @property {boolean} [noFrames] Generate no frames. Not supported in complex output mode.
@@ -18,7 +18,7 @@
  * @property {boolean} [noRoundedCoordinates] Do not round coordinates
  * (with XML output only).
  * @property {string} [outputEncoding] Sets the encoding to use for text output.
- * This defaults to `UTF-8`.
+ * This defaults to `'UTF-8'`.
  * @property {string} [ownerPassword] Owner password (for encrypted files).
  * @property {boolean} [printVersionInfo] Print copyright and version info.
  * @property {boolean} [quiet] Do not print any messages or errors.
@@ -26,10 +26,10 @@
  * @property {boolean} [stdout] Use standard output.
  * @property {string} [userPassword] User password (for encrypted files).
  * @property {number} [wordBreakThreshold] Adjust the word break threshold percent.
- * Default is 10. Word break occurs when distance between two adjacent characters is greater
+ * Default is `10`. Word break occurs when distance between two adjacent characters is greater
  * than this percent of character height.
  * @property {boolean} [xmlOutput] Output for XML post-processing.
- * @property {number} [zoom] Zoom the PDF document (default 1.5).
+ * @property {number} [zoom] Zoom the PDF document (default `1.5`).
  */
 
 /** @type {Record<keyof PdfToHtmlOptions, import("../index").OptionDetails>} */

--- a/src/options/pdftoppm.js
+++ b/src/options/pdftoppm.js
@@ -3,9 +3,9 @@
 /**
  * @typedef PdfToPpmOptions
  * @property {('no'|'yes')} [antialiasFonts] Enable or disable font anti-aliasing.
- * This defaults to `yes`.
+ * This defaults to `'yes'`.
  * @property {('no'|'yes')} [antialiasVectors] Enable or disable vector anti-aliasing.
- * This defaults to `yes`.
+ * This defaults to `'yes'`.
  * @property {boolean} [cropBox] Uses the crop box rather than media box when
  * generating the files (PNG/JPEG/TIFF only).
  * @property {number} [cropHeight] Specifies the height of crop area in pixels
@@ -29,7 +29,7 @@
  * @property {boolean} [evenPagesOnly] Generates only the even numbered pages.
  * @property {number} [firstPageToConvert] Specifies the first page to convert.
  * @property {('no'|'yes')} [freetype] Enable or disable FreeType (a TrueType / Type 1 font rasterizer).
- * This defaults to `yes`.
+ * This defaults to `'yes'`.
  * @property {boolean} [forcePageNumber] Force page number even if there is only one page.
  * @property {boolean} [grayscaleFile] Generate grayscale PGM file (instead of a color PPM file).
  * @property {boolean} [hideAnnotations] Hide annotations.
@@ -38,9 +38,9 @@
  * @property {string} [jpegOptions] When used with `options.jpegFile`, this option can
  * be used to control the JPEG compression parameters. It takes a string of the form
  * `"<opt>=<val>[,<opt>=<val>]"`. Currently available options are:
- * - `quality` Selects the JPEG quality value. The value must be an integer between 0 and 100.
- * - `progressive` Select progressive JPEG output. The possible values are "y", "n", indicating
- * progressive (yes) or non-progressive (no), respectively.
+ * - `quality` Selects the JPEG quality value. The value must be an integer between 0 and 100
+ * - `progressive` Select progressive JPEG output. The possible values are `"y"`, `"n"`, indicating
+ * progressive (yes) or non-progressive (no), respectively
  * @property {number} [lastPageToConvert] Specifies the last page to convert.
  * @property {boolean} [monochromeFile] Generate monochrome PBM file (instead of a color PPM file).
  * @property {boolean} [oddPagesOnly] Generates only the odd numbered pages.
@@ -54,25 +54,25 @@
  * @property {boolean} [printVersionInfo] Print copyright and version information.
  * @property {boolean} [quiet] Do not print any messages or errors.
  * @property {number} [resolutionXAxis] Specifies the X resolution, in pixels per inch of
- * image files (or rasterized regions in vector output). The default is 150 PPI.
+ * image files (or rasterized regions in vector output). The default is `150` PPI.
  * @property {number} [resolutionXYAxis] Specifies the X and Y resolution, in pixels per
- * inch of image files (or rasterized regions in vector output). The default is 150 PPI.
+ * inch of image files (or rasterized regions in vector output). The default is `150` PPI.
  * @property {number} [resolutionYAxis] Specifies the Y resolution, in pixels per inch of
- * image files (or rasterized regions in vector output). The default is 150 PPI.
+ * image files (or rasterized regions in vector output). The default is `150` PPI.
  * @property {boolean} [scaleDimensionBeforeRotation] Swaps horizontal and vertical size for
  * a rotated (landscape) PDF before scaling instead of after.
  * @property {number} [scalePageTo] Scales the long side of each page (width for landscape
  * pages, height for portrait pages) to fit in scale-to pixels. The size of the short side will
  * be determined by the aspect ratio of the page.
  * @property {number} [scalePageToXAxis] Scales each page horizontally to fit in scale-to-x
- * pixels. If scale-to-y is set to -1, the vertical size will be determined by the aspect ratio of
+ * pixels. If scale-to-y is set to `-1`, the vertical size will be determined by the aspect ratio of
  * the page.
  * @property {number} [scalePageToYAxis] Scales each page vertically to fit in scale-to-y
- * pixels. If scale-to-x is set to -1, the horizontal size will be determined by the aspect ratio of
+ * pixels. If scale-to-x is set to `-1`, the horizontal size will be determined by the aspect ratio of
  * the page.
  * @property {string} [separator] Specify single character separator between name and page number.
  * @property {boolean} [singleFile] Writes only the first page and does not add digits.
- * @property {('none'|'shape'|'solid')} [thinLineMode] Specifies the thin line mode. This defaults to `none`.
+ * @property {('none'|'shape'|'solid')} [thinLineMode] Specifies the thin line mode. This defaults to `'none'`.
  * @property {('deflate'|'jpeg'|'lzw'|'none'|'packbits')} [tiffCompression] Set TIFF compression.
  * @property {boolean} [tiffFile] Generate TIFF file instead of a PPM file.
  * @property {string} [userPassword] Specify the user password for the PDF file.

--- a/src/options/pdftops.js
+++ b/src/options/pdftops.js
@@ -75,13 +75,13 @@
  * This option requires `options.processColorFormat` to be CMYK8.
  * @property {string} [ownerPassword] Owner password (for encrypted files).
  * @property {number} [paperHeight] Set the paper height, in points.
- * @property {('A3'|'A4'|'legal'|'letter'|'match')} [paperSize] Set the paper size to one of `A3`, `A4`,
- * `legal`, or `letter`. This can also be set to `match`, which will set the paper size
+ * @property {('A3'|'A4'|'legal'|'letter'|'match')} [paperSize] Set the paper size to one of `'A3'`, `'A4'`,
+ * `'legal'`, or `'letter'`. This can also be set to `'match'`, which will set the paper size
  * of each page to match the size specified in the PDF file. If none of the paperSize,
  * paperWidth, or paperHeight options are specified the default is to match the paper size.
  * @property {number} [paperWidth] Set the paper width, in points.
  * @property {boolean} [passFonts] By default, references to non-embedded 8-bit fonts
- * in the PDF file are substituted with the closest `Helvetica`, `Times-Roman`, or `Courier` font.
+ * in the PDF file are substituted with the closest Helvetica, Times-Roman, or Courier font.
  * This option passes references to non-embedded fonts through to the PostScript file.
  * @property {boolean} [passLevel1CustomColor] When generating Level 1 separable PostScript,
  * preserve custom colors instead of converting them to CMYK.
@@ -91,20 +91,20 @@
  * @property {('CMYK8'|'MONO8'|'RGB8')} [processColorFormat] Sets the process color format as it is used
  * during rasterization and transparency reduction.
  *
- * The default depends on the other settings: For `options.level1` the default is MONO8; for `options.level1Sep`,
- * `options.level2Sep`, `options.level3Sep`, or `options.overprint` the default is CMYK8; in all other
- * cases RGB8 is the default.
+ * The default depends on the other settings: For `options.level1` the default is `'MONO8'`; for `options.level1Sep`,
+ * `options.level2Sep`, `options.level3Sep`, or `options.overprint` the default is `'CMYK8'`; in all other
+ * cases `'RGB8'` is the default.
  * If `options.processColorProfile` is set then `options.processColorFormat` is inferred from the specified ICC profile.
  * @property {string} [processColorProfile] Sets the ICC profile that is assumed during
  * rasterization and transparency reduction.
  * @property {boolean} [quiet] Do not print any messages or errors.
  * @property {('always'|'never'|'whenneeded')} [rasterize] By default, pdfToPs rasterizes pages as needed,
- * for example, if they contain transparencies. To force rasterization, set `rasterize` to `always`.
+ * for example, if they contain transparencies. To force rasterization, set `rasterize` to `'always'`.
  * Use this to eliminate fonts.
- * To prevent rasterization, set `rasterize` to `never`.
+ * To prevent rasterization, set `rasterize` to `'never'`.
  * This may produce files that display incorrectly.
  * @property {number} [resolutionXYAxis] Specifies the X and Y resolution, in pixels per
- * inch of image files (or rasterized regions in vector output). The default is 300 PPI.
+ * inch of image files (or rasterized regions in vector output). The default is `300` PPI.
  * @property {string} [userPassword] User password (for encrypted files).
  */
 

--- a/src/options/pdftotext.js
+++ b/src/options/pdftotext.js
@@ -8,7 +8,7 @@
  * bounding box information for each block, line, and word in the file.
  * @property {number} [columnSpacing] Specifies how much spacing to allow after a word
  * before considering adjacent text to be a new column, measured as a fraction
- * of the font size. Default is 0.7.
+ * of the font size. Default is `0.7`.
  * @property {boolean} [cropBox] Use the crop box rather than the media box with
  * `options.boundingBoxXhtml` and `options.boundingBoxXhtmlLayout`.
  * @property {number} [cropHeight] Specifies the height of crop area in pixels
@@ -37,7 +37,7 @@
  * @property {boolean} [noPageBreaks] Do not insert page breaks (form feed characters)
  * between pages.
  * @property {string} [outputEncoding] Sets the encoding to use for text output.
- * This defaults to `UTF-8`.
+ * This defaults to `'UTF-8'`.
  * @property {string} [ownerPassword] Owner password (for encrypted files).
  * @property {boolean} [printVersionInfo] Print copyright and version information.
  * @property {boolean} [quiet] Do not print any messages or errors.
@@ -45,14 +45,14 @@
  * hack which often undoes column formatting, etc. Use of raw mode is no longer recommended.
  * @property {('all'|'none'|'soft')} [removeHyphens] Controls end-of-line hyphen handling:
  * - `'all'` removes end-of-line hyphens (U+002D, U+2010, U+FE63, U+FF0D) and Unicode
- * soft hyphens (U+00AD), merging words across lines (default).
- * - `'none'` keeps all end-of-line hyphens and line breaks unchanged.
+ * soft hyphens (U+00AD), merging words across lines (default)
+ * - `'none'` keeps all end-of-line hyphens and line breaks unchanged
  * - `'soft'` removes only Unicode soft hyphens (U+00AD), merging words across lines.
- * ASCII and other hyphen characters are preserved.
+ * ASCII and other hyphen characters are preserved
  *
  * This option has no effect when `options.rawLayout` or `options.maintainLayout`
  * are set to `true`.
- * @property {number} [resolution] Specifies the resolution in DPI. Default is 72.
+ * @property {number} [resolution] Specifies the resolution in DPI. Default is `72`.
  * @property {string} [userPassword] User password (for encrypted files).
  */
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md

-->

#### Checklist

- [x] Run `npm test`
- [x] Documentation has been updated and adheres to the style described in [CONTRIBUTING.md](https://github.com/fdawgs/.github/blob/main/CONTRIBUTING.md#documentation-style)
- [x] Commit message adheres to the [Conventional commits](https://conventionalcommits.org/en/v1.0.0) style, following the [@commitlint/config-conventional config](https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional)
