### PR TITLE
ci(cd): pin installed npm version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
               # from package.json before publishing to reduce package size.
               # Force install to bypass OS/CPU checks; does not impact published package
               run: |
-                  npm i -g npm@11 --ignore-scripts
+                  npm i -g npm@11.18.0 --ignore-scripts
                   npm i -f --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies jest scripts
@@ -106,7 +106,7 @@ jobs:
               # from package.json before publishing to reduce package size.
               # Force install to bypass OS/CPU checks; does not impact published package
               run: |
-                  npm i -g npm@11 --ignore-scripts
+                  npm i -g npm@11.18.0 --ignore-scripts
                   npm i -f --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies jest scripts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
               # from package.json before publishing to reduce package size.
               # Force install to bypass OS/CPU checks; does not impact published package
               run: |
-                  npm i -g npm@latest
+                  npm i -g npm@11.18.0 --ignore-scripts
                   npm i -f --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies jest scripts
@@ -106,7 +106,7 @@ jobs:
               # from package.json before publishing to reduce package size.
               # Force install to bypass OS/CPU checks; does not impact published package
               run: |
-                  npm i -g npm@latest
+                  npm i -g npm@11.18.0 --ignore-scripts
                   npm i -f --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies jest scripts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,7 +59,7 @@ jobs:
               # from package.json before publishing to reduce package size.
               # Force install to bypass OS/CPU checks; does not impact published package
               run: |
-                  npm i -g npm@11.18.0 --ignore-scripts
+                  npm i -g npm@11 --ignore-scripts
                   npm i -f --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies jest scripts
@@ -106,7 +106,7 @@ jobs:
               # from package.json before publishing to reduce package size.
               # Force install to bypass OS/CPU checks; does not impact published package
               run: |
-                  npm i -g npm@11.18.0 --ignore-scripts
+                  npm i -g npm@11 --ignore-scripts
                   npm i -f --ignore-scripts
                   npm run build --if-present
                   npm pkg delete commitlint devDependencies jest scripts


### PR DESCRIPTION
'latest' is v12 which dropped support for node 20, which this package is still supporting for time being. [Need v11 for OIDC publishing](https://docs.npmjs.com/trusted-publishers).